### PR TITLE
[Experiment] Generate Contrastive Color

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
 	"name": "word-order",
 	"version": "0.0.1",
 	"private": true,
+	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -17,7 +18,6 @@
 		"@playwright/test": "^1.35.1",
 		"@sveltejs/adapter-auto": "^2.1.0",
 		"@sveltejs/kit": "^1.20.4",
-		"@types/d3-color": "^3.1.0",
 		"@types/dom-to-image": "^2.6.4",
 		"@typescript-eslint/eslint-plugin": "^5.60.0",
 		"@typescript-eslint/parser": "^5.60.0",
@@ -35,10 +35,9 @@
 		"typescript": "^5.1.3",
 		"vite": "^4.3.9"
 	},
-	"type": "module",
 	"dependencies": {
 		"@neodrag/svelte": "^2.0.3",
-		"d3-color": "^3.1.0",
+		"colorjs.io": "^0.5.0",
 		"iconify-icon": "^1.0.8",
 		"typesafe-i18n": "^5.24.3"
 	}

--- a/src/lib/color.ts
+++ b/src/lib/color.ts
@@ -1,8 +1,9 @@
-import * as d3 from 'd3-color';
+import Color from 'colorjs.io';
 
 function* generateEvenlySpacedNumbers(start: number, end: number, n: number): Generator<number> {
   const distance = end - start;
-  const step = distance / n;
+  const coprimeN = (n >>> 1) - +((n & 1) === 0) - +((n & 3) === 2);
+  const step = (distance / n) * coprimeN;
 
   for (let i = 0; i < n; i++) {
     yield start + i * step;
@@ -12,10 +13,9 @@ function* generateEvenlySpacedNumbers(start: number, end: number, n: number): Ge
 type LCh = [l: number, c: number, h: number];
 
 export function pickNColors(n: number): LCh[] {
-  return [...generateEvenlySpacedNumbers(0, 360, n)].map(degrees => [40, 100, degrees]) as LCh[];
+  return [...generateEvenlySpacedNumbers(0, 360, n)].map(degrees => [0.6, 0.25, degrees]) as LCh[];
 }
 
 export function lch2rgb(lch: LCh): string {
-  const [l, c, h] = lch
-  return d3.lch(l, c, h).formatRgb();
+  return new Color('oklch', lch).to('srgb') + '';
 }

--- a/src/lib/color.ts
+++ b/src/lib/color.ts
@@ -2,7 +2,7 @@ import * as d3 from 'd3-color';
 
 function* generateEvenlySpacedNumbers(start: number, end: number, n: number): Generator<number> {
   const distance = end - start;
-  const step = distance / (n - 1);
+  const step = distance / n;
 
   for (let i = 0; i < n; i++) {
     yield start + i * step;
@@ -12,7 +12,7 @@ function* generateEvenlySpacedNumbers(start: number, end: number, n: number): Ge
 type LCh = [l: number, c: number, h: number];
 
 export function pickNColors(n: number): LCh[] {
-  return [...generateEvenlySpacedNumbers(0, 360, n + 1)].map(degrees => [40, 100, degrees]).slice(0, -1) as LCh[];
+  return [...generateEvenlySpacedNumbers(0, 360, n)].map(degrees => [40, 100, degrees]) as LCh[];
 }
 
 export function lch2rgb(lch: LCh): string {


### PR DESCRIPTION
This is actually the main reason I look into this repo. Currently, adjacent word pairs are hardly distinguishable especially for writing systems without word boundary. However I failed to find a good solution on this issue.
What I am thinking is that the generated colors should satisfy the following criteria:

1. Colors should be generated in a deterministic manner.
2. All of them (not only the adjacent pairs since their order can be interchanged by the user) should be distinctive to each other, e.g. the [minimum color distance](https://colorjs.io/docs/color-difference) between each of them should be larger than a specific number.
3. All of them should be contrastive to the background, e.g. the contrast calculated by one of [the algorithms listed here](https://colorjs.io/docs/contrast) should be larger than a specific number.
4. The resulting palette should be color blind friendly, i.e. Point 2. should still be satisfied after mapping the colors with the transformation, e.g., [the matrices given here](https://www.inf.ufrgs.br/~oliveira/pubs_files/CVD_Simulation/CVD_Simulation.html).

I found a [good article](https://www.realtimerendering.com/blog/low-discrepancy-color-sequences-part-deux/) on generating distinctive color with low discrepancy sequences, but since low discrepancy sequences are infinite, the resulting colors don’t seem suitable for the case where the palette is finite. Plus, the colors given by the article don’t satisfy point 3 above.

I have also tried ordinary solutions like using the [`randomcolor` npm package](https://www.npmjs.org/package/randomcolor), but the generated colors are simply not distinctive enough.