### PR TITLE
fix(input): render the word above the gloss input through Word component

### DIFF
--- a/src/lib/Output.svelte
+++ b/src/lib/Output.svelte
@@ -385,7 +385,7 @@
 							<!-- svelte-ignore a11y-click-events-have-key-events -->
 							<span class="token" class:with-gloss={sentenceShowsGloss(sentence) && isContent(word)}>
 								{#if sentenceShowsGloss(sentence) && isContent(word)}
-									<span class="gloss-token"><Word word={token.gloss} /></span>
+									<span class="gloss-token">{isContent(word) ? token.gloss : ''}</span>
 								{/if}
 								<span
 									class="word"

--- a/src/lib/Output.svelte
+++ b/src/lib/Output.svelte
@@ -385,7 +385,7 @@
 							<!-- svelte-ignore a11y-click-events-have-key-events -->
 							<span class="token" class:with-gloss={sentenceShowsGloss(sentence) && isContent(word)}>
 								{#if sentenceShowsGloss(sentence) && isContent(word)}
-									<span class="gloss-token">{isContent(word) ? token.gloss : ''}</span>
+									<span class="gloss-token"><Word word={token.gloss} /></span>
 								{/if}
 								<span
 									class="word"

--- a/src/lib/SentenceInput.svelte
+++ b/src/lib/SentenceInput.svelte
@@ -5,6 +5,7 @@
 	import { tokenizeSentence } from './tokenize';
 	import type { Sentence } from './types';
 	import { createSentenceTokens, getSentenceGlosses, getSentenceWords } from './types';
+	import Word from './Word.svelte';
 
 	export let modifying: number;
 	export let sentences: Sentence[];
@@ -102,7 +103,7 @@
 						{#each glossTokens as token, index}
 							{#if isGlossableToken(token.text)}
 								<label class="gloss-field" for={`gloss-${index}`}>
-									<span class="gloss-word" {lang}>{token.text}</span>
+									<span class="gloss-word" {lang}><Word word={token.text} /></span>
 									<input id={`gloss-${index}`} type="text" bind:value={glosses[index]} placeholder={$LL.input.glossPlaceholder()} />
 								</label>
 							{/if}


### PR DESCRIPTION
## Summary
The word shown as the label above each gloss input field rendered as plain text, so a token like \`<ruby>漢<rt>かん</rt></ruby>\` showed escaped HTML instead of the ruby annotation.

Routes that label through the existing \`<Word>\` component so ruby (furigana, pinyin, zhuyin, etc.) renders the same way it does in the sentence row.

## Out of scope
Earlier drafts of this PR also routed the **gloss text in the output** through \`<Word>\`. Reverted — gloss is itself an above-the-word annotation (1SG, TOP, ACC, …), so allowing ruby or arbitrary HTML inside it doesn't make linguistic sense.

## Scope
- \`src/lib/SentenceInput.svelte\`: \`{token.text}\` → \`<Word word={token.text} />\` + the missing \`import Word\`
- \`src/lib/Output.svelte\`: untouched (gloss output stays plain text)

+2 / -1 across one file.