### PR TITLE
feat(autosave): persist sentences and equivalency to localStorage

### DIFF
--- a/project.inlang/messages/en.json
+++ b/project.inlang/messages/en.json
@@ -47,6 +47,7 @@
 	"dialog_cancel": "Cancel",
 	"confirm_delete_sentence": "Are you sure you want to delete this sentence?",
 	"confirm_new": "Are you sure you want to create a new illustration? This will DELETE everything!!!",
+	"confirm_import": "Import this file? Your current sentences and connections will be replaced.",
 	"menu_new": "New",
 	"menu_import": "Import",
 	"menu_export": "Export",

--- a/src/i18n/i18n-svelte.ts
+++ b/src/i18n/i18n-svelte.ts
@@ -66,7 +66,8 @@ const createLL = () => ({
 	},
 	confirm: {
 		deleteSentence: m.confirm_delete_sentence,
-		new: m.confirm_new
+		new: m.confirm_new,
+		import: m.confirm_import
 	},
 	menu: {
 		new: m.menu_new,

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -1,0 +1,72 @@
+import type { Sentence, SentenceData } from './types';
+import { normalizeSentence } from './types';
+
+export type PersistedDoc = {
+	schemaVersion: 1;
+	sentences: Sentence[];
+	equivalency: number[][][];
+};
+
+const STORAGE_KEY = 'word-order:state';
+const SCHEMA_VERSION = 1 as const;
+
+type LegacyDoc = { sentences: SentenceData[]; equivalency: number[][][] };
+
+export function docFromLegacy(doc: LegacyDoc): PersistedDoc {
+	return {
+		schemaVersion: SCHEMA_VERSION,
+		sentences: doc.sentences.map(normalizeSentence),
+		equivalency: doc.equivalency
+	};
+}
+
+export function docToLegacy(doc: { sentences: Sentence[]; equivalency: number[][][] }): LegacyDoc {
+	return { sentences: doc.sentences, equivalency: doc.equivalency };
+}
+
+export function isDocEmpty(doc: { sentences: Sentence[]; equivalency: number[][][] }): boolean {
+	return doc.sentences.length === 0 && doc.equivalency.length === 0;
+}
+
+export function loadDoc(): PersistedDoc | null {
+	if (typeof localStorage === 'undefined') return null;
+
+	const raw = localStorage.getItem(STORAGE_KEY);
+	if (!raw) return null;
+
+	try {
+		const parsed = JSON.parse(raw);
+
+		if (
+			parsed &&
+			typeof parsed === 'object' &&
+			parsed.schemaVersion === SCHEMA_VERSION &&
+			Array.isArray(parsed.sentences) &&
+			Array.isArray(parsed.equivalency)
+		) {
+			return {
+				schemaVersion: SCHEMA_VERSION,
+				sentences: parsed.sentences.map(normalizeSentence),
+				equivalency: parsed.equivalency
+			};
+		}
+
+		// Tolerate raw {sentences, equivalency} JSON (exported files, older draft shapes)
+		if (parsed && typeof parsed === 'object' && Array.isArray(parsed.sentences) && Array.isArray(parsed.equivalency)) {
+			return docFromLegacy(parsed as LegacyDoc);
+		}
+	} catch {
+		// fall through
+	}
+
+	return null;
+}
+
+export function saveDoc(doc: PersistedDoc): void {
+	if (typeof localStorage === 'undefined') return;
+	try {
+		localStorage.setItem(STORAGE_KEY, JSON.stringify(doc));
+	} catch {
+		// quota or other failure — best effort
+	}
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -13,6 +13,7 @@
 
 	import type { Alignment, FontFamily, FontStyle, Mode, Sentence, SentenceData } from '$lib/types';
 	import { createSentence, getSentenceGlosses, getSentenceWords, normalizeSentence } from '$lib/types';
+	import { docFromLegacy, isDocEmpty, loadDoc, saveDoc } from '$lib/projects';
 
 	// Components
 	import AboutDialog from '$lib/AboutDialog.svelte';
@@ -91,13 +92,26 @@
 	let aboutOpen = false;
 
 	let mounted = false;
-	onMount(() => {
+	onMount(async () => {
 		const rem = parseFloat(window.getComputedStyle(document.documentElement).fontSize);
 		verticalGap = Math.round(2 * rem);
 		lineGap = Math.round(0.3 * rem);
 
+		// Restore the user's last illustration from localStorage. If nothing is stored,
+		// keep the seeded sample sentences/equivalency above as the first-visit default.
+		const doc = loadDoc();
+		if (doc) {
+			sentences = doc.sentences;
+			equivalency = doc.equivalency;
+		}
+
 		mounted = true;
+		await tick();
+		word_spans = sentences.map(() => []);
 	});
+
+	// Autosave on any change to sentences or equivalency.
+	$: if (mounted) saveDoc({ schemaVersion: 1, sentences, equivalency });
 
 	$: if (mounted) calculate_color_map(equivalency);
 	function calculate_color_map(equivalency: number[][][]) {
@@ -269,9 +283,13 @@
 	}
 
 	async function load(data: { equivalency: number[][][]; sentences: SentenceData[] }) {
+		if (!isDocEmpty({ sentences, equivalency }) && !confirm($LL.confirm.import())) return;
+		const next = docFromLegacy(data);
+		if (modifying !== -1) cancelUnchangedEdit();
+		mode = 'view';
 		loading = true;
-		sentences = data.sentences.map(normalizeSentence);
-		equivalency = data.equivalency;
+		sentences = next.sentences;
+		equivalency = next.equivalency;
 		await tick();
 		word_spans = sentences.map(() => []);
 		loading = false;


### PR DESCRIPTION
## Summary
Refreshing or closing the tab no longer loses work, and Import now confirms before replacing an in-progress illustration.

## Changes
- New \`src/lib/projects.ts\` with \`loadDoc\` / \`saveDoc\` / \`docFromLegacy\` / \`docToLegacy\` / \`isDocEmpty\` (no example dependency — kept minimal).
- \`onMount\` hydrates from localStorage; first-visit keeps the seeded sample illustration.
- Reactive \`saveDoc(...)\` fires on any \`sentences\` / \`equivalency\` change.
- Import path checks \`isDocEmpty\` and \`confirm()\`s before swapping; also cancels any in-progress sentence edit and resets \`mode\` to \`'view'\` before applying the new doc.
- New i18n key \`confirm_import\` in \`en.json\`; other 31 locales fall back to English until translated.

+4 files changed, +96 / −4.

## Context
Extracted from the original [#23](https://github.com/mkpoli/word-order/pull/23). The examples gallery half follows in #(examples-gallery PR), which stacks on top of this one.

## Test plan
- [x] \`bun run check\` — 0 errors
- [ ] Refresh the page — last-edited illustration restores
- [ ] First-visit (clear localStorage) — sample seed loads
- [ ] Import a JSON file with non-empty doc → confirm prompt; cancelling keeps current doc
- [ ] Import with empty doc → no prompt, just loads