### PR TITLE
fix(layout): contain horizontal overflow inside .output on small screens

### DIFF
--- a/src/lib/Output.svelte
+++ b/src/lib/Output.svelte
@@ -655,6 +655,10 @@
 		column-gap: 1em;
 		row-gap: 0.65em;
 		width: fit-content;
+		/* Centers within the scrollable .output wrapper when content fits;
+		   when content overflows, the wrapper scrolls horizontally instead of
+		   pushing the page off-screen. */
+		margin-inline: auto;
 	}
 
 	svg {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -801,10 +801,11 @@
 
 	.output {
 		padding: 0;
-		display: flex;
-		justify-content: center;
 		position: relative;
 		z-index: 1;
+		overflow-x: auto;
+		-webkit-overflow-scrolling: touch;
+		overscroll-behavior-x: contain;
 		transition:
 			box-shadow 180ms ease,
 			border-color 180ms ease,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -804,6 +804,12 @@
 		position: relative;
 		z-index: 1;
 		overflow-x: auto;
+		/* overflow-y: clip — not auto — keeps the absolute-positioned ::after
+		   indicator below visible without enabling a vertical scrollbar. The
+		   spec downgrades overflow-y: visible to auto whenever overflow-x is
+		   non-visible, but clip is allowed to coexist with auto on the other axis. */
+		overflow-y: clip;
+		overflow-clip-margin: 2rem;
 		-webkit-overflow-scrolling: touch;
 		overscroll-behavior-x: contain;
 		transition:


### PR DESCRIPTION
## Problem
On narrow phones, the \`<output>\` element uses \`width: fit-content\` so a multi-language sentence row stretches the element wider than the viewport. The page (not the \`.output\` wrapper) became horizontally scrollable, content shifted off-centre, and the connector SVG looked cropped or "crashed".

## Fix

**\`.output\` wrapper (\`+page.svelte\`):**
- Drop \`display: flex; justify-content: center\`
- Add \`overflow-x: auto\` so the wrapper handles the scroll, not the body
- \`-webkit-overflow-scrolling: touch\` + \`overscroll-behavior-x: contain\` so iOS gets smooth scrolling and doesn't trigger a back-gesture

**\`<output>\` element (\`Output.svelte\`):**
- Keep \`width: fit-content\` (grid columns still size to content)
- Add \`margin-inline: auto\` so it still centres when it fits, and gracefully falls back to start-aligned + scrollable when it doesn't

## Why the SVG still aligns

Connector coordinates are computed relative to \`output.getBoundingClientRect()\`, and the SVG is \`position: absolute; width: 100%; height: 100%\` inside that output. Horizontally scrolling \`.output\` translates the entire \`<output>\` element (including its SVG) as a unit, so the paths stay glued to the tokens — no redraw needed on scroll.

## Test plan
- [x] \`bun run check\` — 0 errors
- [x] \`bun run dev\` — boots clean
- [ ] On a phone-width viewport, the page no longer scrolls horizontally as a whole
- [ ] The \`.output\` row scrolls horizontally instead, and connector lines stay glued to the words
- [ ] When the content fits, the diagram is still horizontally centred
- [ ] Editing mode (with the blue border/padding around \`.output\`) still looks right


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved output container scrolling behavior with enhanced horizontal scroll handling and better content centering for improved layout consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mkpoli/word-order/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->