### PR TITLE
fix(layout): kill the spurious vertical scrollbar on .output

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -513,8 +513,9 @@
 
 <main>
 	<div class="output" class:editing-active={modifying !== -1} bind:this={outputContainer}>
-		{#if mounted}
-			<Output
+		<div class="output-scroll">
+			{#if mounted}
+				<Output
 				sentences={previewSentences}
 				{color_map}
 				{equivalency}
@@ -600,6 +601,7 @@
 				}}
 			/>
 		{/if}
+		</div>
 	</div>
 
 	<div class="input" class:editing-active={modifying !== -1} bind:this={inputContainer}>
@@ -803,21 +805,22 @@
 		padding: 0;
 		position: relative;
 		z-index: 1;
-		overflow-x: auto;
-		/* overflow-y: clip — not auto — keeps the absolute-positioned ::after
-		   indicator below visible without enabling a vertical scrollbar. The
-		   spec downgrades overflow-y: visible to auto whenever overflow-x is
-		   non-visible, but clip is allowed to coexist with auto on the other axis. */
-		overflow-y: clip;
-		overflow-clip-margin: 2rem;
-		-webkit-overflow-scrolling: touch;
-		overscroll-behavior-x: contain;
 		transition:
 			box-shadow 180ms ease,
 			border-color 180ms ease,
 			transform 180ms ease,
 			opacity 180ms ease,
 			filter 180ms ease;
+	}
+
+	/* Horizontal scroll lives on this inner wrapper, not on .output itself,
+	   so .output's overflow stays visible and the ::after editing indicator
+	   below the box can render. */
+	.output-scroll {
+		overflow-x: auto;
+		overflow-y: hidden;
+		-webkit-overflow-scrolling: touch;
+		overscroll-behavior-x: contain;
 	}
 
 	.output::after {


### PR DESCRIPTION
## Problem
PR #38 added \`overflow-x: auto\` + \`overflow-y: clip\` on \`.output\` to give the connector diagram horizontal scroll on narrow screens without enabling a vertical one. In practice, browsers still showed a vertical scrollbar — probably because the absolute-positioned \`.output::after\` editing indicator below the box was treated as overflowing content despite the clip directive.

## Fix
Split the responsibility:

- \`.output\` goes back to default \`overflow: visible\` — the \`::after\` indicator below the box renders normally.
- A new inner \`.output-scroll\` div wraps the \`<Output>\` component and carries \`overflow-x: auto; overflow-y: hidden\`. Since this is a separate element, the editing indicator on \`.output\` isn't affected by its overflow.

Net change: 1 file, +14 / -11. No vertical scroll. Horizontal scroll still works. Editing indicator still visible.

## Test plan
- [x] \`bun run check\` — 0 errors
- [x] \`bun run dev\` — boots clean
- [ ] On a phone-width viewport: \`.output\` should scroll horizontally only, no vertical scrollbar
- [ ] The blue gradient editing-mode indicator below \`.output\` still appears when editing
- [ ] On desktop with wide content: same — horizontal-only scroll within the band