### PR TITLE
feat(gloss): tokens size to gloss width, expose gloss font size

### DIFF
--- a/project.inlang/messages/en.json
+++ b/project.inlang/messages/en.json
@@ -24,6 +24,7 @@
 	"params_bold": "Bold",
 	"params_bold_italic": "Bold Italic",
 	"params_font_size": "Font Size",
+	"params_gloss_font_size": "Gloss Font Size",
 	"params_space_width": "Space Width",
 	"input_input": "Input",
 	"input_placeholder": "Input new sentence here…",

--- a/src/i18n/i18n-svelte.ts
+++ b/src/i18n/i18n-svelte.ts
@@ -32,6 +32,7 @@ const createLL = () => ({
 		bold: m.params_bold,
 		boldItalic: m.params_bold_italic,
 		fontSize: m.params_font_size,
+		glossFontSize: m.params_gloss_font_size,
 		spaceWidth: m.params_space_width
 	},
 	input: {

--- a/src/lib/Output.svelte
+++ b/src/lib/Output.svelte
@@ -63,6 +63,7 @@
 	export let fontFamily: FontFamily;
 	export let fontStyle: FontStyle;
 	export let fontSize: number;
+	export let glossFontSize: number;
 	export let spaceWidth: number;
 	export let mode: Mode = 'view';
 
@@ -385,7 +386,7 @@
 							<!-- svelte-ignore a11y-click-events-have-key-events -->
 							<span class="token" class:with-gloss={sentenceShowsGloss(sentence) && isContent(word)}>
 								{#if sentenceShowsGloss(sentence) && isContent(word)}
-									<span class="gloss-token">{isContent(word) ? token.gloss : ''}</span>
+									<span class="gloss-token" style:font-size={`${glossFontSize}px`}>{isContent(word) ? token.gloss : ''}</span>
 								{/if}
 								<span
 									class="word"
@@ -593,10 +594,6 @@
 		display: block;
 	}
 
-	.sentence-body.with-gloss {
-		padding-top: 1.35em;
-	}
-
 	.words {
 		display: block;
 	}
@@ -613,15 +610,11 @@
 		white-space: pre;
 	}
 
+	/* Gloss sits above the word in normal flow so the token's width grows to
+	   max(word, gloss) — wide gloss text no longer overflows onto neighbours. */
 	.gloss-token {
 		display: block;
-		position: absolute;
-		left: 50%;
-		bottom: 100%;
-		min-width: 100%;
-		transform: translateX(-50%);
 		text-align: center;
-		font-size: 0.74em;
 		line-height: 1.2;
 		letter-spacing: 0.02em;
 		color: rgb(86 92 120);

--- a/src/lib/Parameters.svelte
+++ b/src/lib/Parameters.svelte
@@ -15,6 +15,7 @@
 	export let fontFamily: FontFamily = 'default';
 	export let fontStyle: FontStyle = 'normal';
 	export let fontSize = 15;
+	export let glossFontSize = 11;
 	export let spaceWidth = 4;
 
 	$: lineGap = Math.min(lineGap, verticalGap / 2);
@@ -122,6 +123,12 @@
 		{$LL.params.fontSize()}
 	</label>
 	<RangeSlider bind:value={fontSize} id="font-size" min={10} max={30} suffix=" px" />
+
+	<label for="gloss-font-size">
+		<iconify-icon icon="mdi:format-annotation-plus" inline="true" />
+		{$LL.params.glossFontSize()}
+	</label>
+	<RangeSlider bind:value={glossFontSize} id="gloss-font-size" min={6} max={24} suffix=" px" />
 
 	<label for="space-width">
 		<iconify-icon icon="mdi:format-horizontal-align-center" inline="true" />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -12,7 +12,7 @@
 	import { getCanonicalUrl, getJsonLd, getOgImageUrl, themeColor } from '$lib/seo';
 
 	import type { Alignment, FontFamily, FontStyle, Mode, Sentence, SentenceData } from '$lib/types';
-	import { createSentence, getSentenceGlosses, getSentenceWords, normalizeSentence } from '$lib/types';
+	import { createSentence, getSentenceGlosses, getSentenceWords } from '$lib/types';
 	import { docFromLegacy, isDocEmpty, loadDoc, saveDoc } from '$lib/projects';
 
 	// Components

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -86,6 +86,7 @@
 	let fontFamily: FontFamily;
 	let fontStyle: FontStyle;
 	let fontSize: number;
+	let glossFontSize = 11;
 	let spaceWidth = 4;
 
 	let aboutOpen = false;
@@ -530,6 +531,7 @@
 				{fontFamily}
 				{fontStyle}
 				{fontSize}
+				{glossFontSize}
 				{spaceWidth}
 				{loading}
 				{modifying}
@@ -625,6 +627,7 @@
 			bind:fontFamily
 			bind:fontStyle
 			bind:fontSize
+			bind:glossFontSize
 			bind:spaceWidth
 		/>
 	</div>


### PR DESCRIPTION
## Problem
A wide gloss above a short word (e.g. \`2PL.POSS\` over \`iniz\`, or any Leipzig-style multi-feature gloss over a 2-character morpheme) used to overflow onto adjacent tokens. The gloss was \`position: absolute\` and didn't push the token wider; only a \`padding-top: 1.35em\` on the sentence body reserved vertical room.

## Fix

1. **Layout** — drop \`position: absolute\` on \`.gloss-token\`. The gloss now sits above the word in normal flow inside the token's \`inline-block\`. Each token's width grows to \`max(word, gloss)\` automatically. Side benefit: the \`padding-top: 1.35em\` hack on \`.sentence-body.with-gloss\` is no longer needed and is removed.

2. **Font size** — replace the hardcoded \`0.74em\` with a new \`glossFontSize\` parameter (default 11 px, slider range 6–24). Wired through \`Parameters.svelte\` → \`+page.svelte\` → \`Output.svelte\`, applied inline on each \`.gloss-token\`.

## Connector geometry
Unchanged. \`drawLines\` still finds gloss elements via \`span.parentElement?.querySelector('.gloss-token')\` and uses their top as the connector endpoint. With gloss in flow rather than absolute, the gloss's bounding rect is *exactly* where the connector should land, so no math changes.

## i18n
One new key: \`params_gloss_font_size\` (\"Gloss Font Size\") in \`en.json\`. The other 31 locales fall back to English until translated in a follow-up commit.

## Test plan
- [x] \`bun run check\` — 0 errors, 6 warnings (baseline)
- [x] Per-file prettier check — clean
- [ ] Load the **Turkish gloss** example: \`2PL.POSS\` no longer cramps \`iniz\`, \`PROG\` no longer cramps \`yor\`
- [ ] Load **SOV vs SVO** / **Pro-drop**: glosses fit cleanly above each token
- [ ] Slide the new Gloss Font Size to 6, 11, and 24 — the diagram resizes correctly and connectors track the gloss top
- [ ] Toggle gloss off (in SentenceInput): non-glossed sentences look identical to before — no leftover padding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a "Gloss Font Size" control in text settings, enabling users to adjust gloss text size via slider (range: 6–24 pixels, default: 11)
  * Improved gloss rendering with enhanced styling and layout integration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mkpoli/word-order/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->