### PR TITLE
fix(layout): connector lines vanishing on refresh / load from storage

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -105,9 +105,13 @@
 			equivalency = doc.equivalency;
 		}
 
+		// Initialise word_spans to the right shape BEFORE Output mounts so its
+		// bind:this writes have a valid array to write into. Resetting it after
+		// mount + tick would clobber the just-populated bindings and leave the
+		// connector SVG empty until the next user interaction.
+		word_spans = sentences.map(() => []);
 		mounted = true;
 		await tick();
-		word_spans = sentences.map(() => []);
 	});
 
 	// Autosave on any change to sentences or equivalency.
@@ -534,91 +538,91 @@
 		<div class="output-scroll">
 			{#if mounted}
 				<Output
-				sentences={previewSentences}
-				{color_map}
-				{equivalency}
-				{alignment}
-				bind:lines
-				{colors}
-				{verticalGap}
-				{lineGap}
-				{lineWidth}
-				{straightLength}
-				{endpointCorrection}
-				{curvature}
-				{fontFamily}
-				{fontStyle}
-				{fontSize}
-				{spaceWidth}
-				{loading}
-				{modifying}
-				{editingSelectionStart}
-				{editingSelectionEnd}
-				bind:word_spans
-				bind:mode
-				bind:output
-				on:connect={onconnect}
-				on:reorder={({ detail: { from, to } }) => {
-					const sentence = sentences[from];
-					sentences.splice(from, 1);
-					sentences.splice(to, 0, sentence);
-					sentences = sentences;
+					sentences={previewSentences}
+					{color_map}
+					{equivalency}
+					{alignment}
+					bind:lines
+					{colors}
+					{verticalGap}
+					{lineGap}
+					{lineWidth}
+					{straightLength}
+					{endpointCorrection}
+					{curvature}
+					{fontFamily}
+					{fontStyle}
+					{fontSize}
+					{spaceWidth}
+					{loading}
+					{modifying}
+					{editingSelectionStart}
+					{editingSelectionEnd}
+					bind:word_spans
+					bind:mode
+					bind:output
+					on:connect={onconnect}
+					on:reorder={({ detail: { from, to } }) => {
+						const sentence = sentences[from];
+						sentences.splice(from, 1);
+						sentences.splice(to, 0, sentence);
+						sentences = sentences;
 
-					for (const [i, entry] of equivalency.entries()) {
-						const value = entry[from];
-						entry.splice(from, 1);
-						entry.splice(to, 0, value);
-						equivalency[i] = entry;
-					}
-					equivalency = equivalency;
-				}}
-				on:delete={({ detail: { sentence } }) => {
-					sentences.splice(sentence, 1);
-					sentences = sentences;
+						for (const [i, entry] of equivalency.entries()) {
+							const value = entry[from];
+							entry.splice(from, 1);
+							entry.splice(to, 0, value);
+							equivalency[i] = entry;
+						}
+						equivalency = equivalency;
+					}}
+					on:delete={({ detail: { sentence } }) => {
+						sentences.splice(sentence, 1);
+						sentences = sentences;
 
-					for (const [i, entry] of equivalency.entries()) {
-						entry.splice(sentence, 1);
-						equivalency[i] = entry;
-					}
-					equivalency = equivalency;
-				}}
-				on:modify={({ detail: { sentence } }) => {
-					modifying = sentence;
-					wordsBeforeModify = getSentenceWords(sentences[sentence]);
-					editingText = wordsBeforeModify.join('|');
-					glossesBeforeModify = [...getSentenceGlosses(sentences[sentence])];
-					editingGlosses = [...glossesBeforeModify];
-					editingShowGloss = sentences[sentence].showGloss;
-					editingSelectionStart = -1;
-					editingSelectionEnd = -1;
-				}}
-				on:merge={({ detail: { sentence, start, end } }) => {
-					const words = getSentenceWords(previewSentences[sentence]);
-					const glosses = getSentenceGlosses(previewSentences[sentence]);
-					const merged = words.slice(start, end + 1).join('');
-					editingText = [...words.slice(0, start), merged, ...words.slice(end + 1)].join('|');
-					editingGlosses = [
-						...glosses.slice(0, start),
-						glosses
-							.slice(start, end + 1)
-							.filter(Boolean)
-							.join('-'),
-						...glosses.slice(end + 1)
-					];
-					editingSelectionStart = start;
-					editingSelectionEnd = start;
-				}}
-				on:split={({ detail: { sentence, word, offset } }) => {
-					const words = getSentenceWords(previewSentences[sentence]);
-					const glosses = getSentenceGlosses(previewSentences[sentence]);
-					const token = words[word];
-					editingText = [...words.slice(0, word), token.slice(0, offset), token.slice(offset), ...words.slice(word + 1)].filter(Boolean).join('|');
-					editingGlosses = [...glosses.slice(0, word), glosses[word] ?? '', glosses[word] ?? '', ...glosses.slice(word + 1)];
-					editingSelectionStart = word;
-					editingSelectionEnd = word + 1;
-				}}
-			/>
-		{/if}
+						for (const [i, entry] of equivalency.entries()) {
+							entry.splice(sentence, 1);
+							equivalency[i] = entry;
+						}
+						equivalency = equivalency;
+					}}
+					on:modify={({ detail: { sentence } }) => {
+						modifying = sentence;
+						wordsBeforeModify = getSentenceWords(sentences[sentence]);
+						editingText = wordsBeforeModify.join('|');
+						glossesBeforeModify = [...getSentenceGlosses(sentences[sentence])];
+						editingGlosses = [...glossesBeforeModify];
+						editingShowGloss = sentences[sentence].showGloss;
+						editingSelectionStart = -1;
+						editingSelectionEnd = -1;
+					}}
+					on:merge={({ detail: { sentence, start, end } }) => {
+						const words = getSentenceWords(previewSentences[sentence]);
+						const glosses = getSentenceGlosses(previewSentences[sentence]);
+						const merged = words.slice(start, end + 1).join('');
+						editingText = [...words.slice(0, start), merged, ...words.slice(end + 1)].join('|');
+						editingGlosses = [
+							...glosses.slice(0, start),
+							glosses
+								.slice(start, end + 1)
+								.filter(Boolean)
+								.join('-'),
+							...glosses.slice(end + 1)
+						];
+						editingSelectionStart = start;
+						editingSelectionEnd = start;
+					}}
+					on:split={({ detail: { sentence, word, offset } }) => {
+						const words = getSentenceWords(previewSentences[sentence]);
+						const glosses = getSentenceGlosses(previewSentences[sentence]);
+						const token = words[word];
+						editingText = [...words.slice(0, word), token.slice(0, offset), token.slice(offset), ...words.slice(word + 1)].filter(Boolean).join('|');
+						editingGlosses = [...glosses.slice(0, word), glosses[word] ?? '', glosses[word] ?? '', ...glosses.slice(word + 1)];
+						editingSelectionStart = word;
+						editingSelectionEnd = word + 1;
+					}}
+				/>
+			{/if}
 		</div>
 	</div>
 


### PR DESCRIPTION
## Symptom
After a refresh (or any load from localStorage on mount), the connector SVG was empty: \`<svg width=\"100%\" height=\"100%\">\` with **no \`<path>\` children**, even though every sentence and the equivalency panel rendered correctly. Switching to a different example via the Examples dropdown made the lines re-appear normally.

## Root cause
\`+page.svelte\`'s \`onMount\` had this order:

\`\`\`ts
mounted = true;       // ① triggers Output to mount, bind:this populates word_spans
await tick();         // ② waits for that
word_spans = sentences.map(() => []);  // ③ CLOBBERS the just-populated array
\`\`\`

Step ③ replaced the array Output's \`<span bind:this={word_spans[i][j]}>\` had just written into. \`word_spans\` now pointed to fresh empty inner arrays, the existing DOM bindings still wrote to the **old** array (now orphaned), and the reactive \`lines = drawLines(word_spans, ...)\` ran against the new empty one — returning an empty \`lines\` and producing no paths.

It didn't repro for the Examples dropdown because that path resets \`word_spans\` before the new sentences are assigned, so the next render's bindings populate the fresh array; the refresh path didn't have that ordering.

## Fix
Move the \`word_spans\` initialisation **before** \`mounted = true\` so the array exists at the right shape when Output mounts and its bindings fire into it. Drop the post-tick reset.

\`\`\`ts
// Initialise word_spans to the right shape BEFORE Output mounts so its
// bind:this writes have a valid array to write into.
word_spans = sentences.map(() => []);
mounted = true;
await tick();
\`\`\`

## Diff
One file (\`src/routes/+page.svelte\`). The meaningful change is 4 lines moved + a comment; prettier also reflowed the \`<Output ...>\` prop-list indentation in passing, behaviour unchanged.

## Test plan
- [x] \`bun run check\` — 0 errors
- [ ] Load the page, modify the diagram, refresh — connector lines reappear immediately
- [ ] Same with an autosaved doc whose first paint is the restored one (no jump or empty-SVG flash)
- [ ] Switching examples still works (sanity check that the working path didn't regress)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed initialization ordering during startup to ensure the application loads correctly and reliably with all necessary components properly initialized.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mkpoli/word-order/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->