### PR TITLE
fix(output): RTL sentence direction (#41) + unbreakable language tag (#29)

### DIFF
--- a/src/lib/Output.svelte
+++ b/src/lib/Output.svelte
@@ -7,7 +7,7 @@
 	import { onMount, tick, createEventDispatcher } from 'svelte';
 	import type { Alignment, FontFamily, FontStyle, Mode, Sentence } from '$lib/types';
 	import { getSentenceWords } from '$lib/types';
-	import { getLanguageName } from './lang';
+	import { getLanguageName, getLocaleDirection } from './lang';
 	import { LL, locale } from '$i18n/i18n-svelte';
 	import Word from './Word.svelte';
 
@@ -379,7 +379,7 @@
 				</div>
 				<span class="tag" style:transform={getTransform(i, draggingOffset)}>{getLanguageName(lang, $locale)}</span>
 				<div class="sentence-body" class:with-gloss={sentenceShowsGloss(sentence)} style:transform={getTransform(i, draggingOffset)}>
-					<span class="words" {lang} style:text-align={alignment}>
+					<span class="words" {lang} dir={getLocaleDirection(lang)} style:text-align={alignment}>
 						{#each tokens as token, j}
 							{@const word = token.text}
 							<!-- svelte-ignore a11y-click-events-have-key-events -->
@@ -587,6 +587,7 @@
 		font-weight: bold;
 		text-align: center;
 		margin-right: 2em;
+		white-space: nowrap;
 	}
 
 	.sentence-body {

--- a/src/lib/lang.ts
+++ b/src/lib/lang.ts
@@ -68,7 +68,22 @@ const LOCALE_OPTIONS: LocaleOption[] = [
 ];
 
 export function getLocaleDirection(locale: string): 'ltr' | 'rtl' {
-	return ['ar', 'fa'].includes(locale) ? 'rtl' : 'ltr';
+	if (!locale) return 'ltr';
+	// Modern browsers expose direction info per BCP-47 locale; covers Hebrew,
+	// Arabic, Persian, Urdu, etc. without us maintaining a list. The TS lib for
+	// the project doesn't yet declare getTextInfo, so cast.
+	try {
+		const intlLocale = new Intl.Locale(locale) as Intl.Locale & {
+			getTextInfo?: () => { direction: 'ltr' | 'rtl' };
+		};
+		const info = intlLocale.getTextInfo?.();
+		if (info?.direction === 'rtl') return 'rtl';
+		if (info?.direction === 'ltr') return 'ltr';
+	} catch {
+		// fall through
+	}
+	const base = locale.split(/[-_]/)[0].toLowerCase();
+	return ['ar', 'fa', 'he', 'ur', 'ps', 'yi', 'dv', 'ks', 'sd', 'ckb'].includes(base) ? 'rtl' : 'ltr';
 }
 
 export function getLocaleOptions(displayLocale: string): (LocaleOption & { exonym: string })[] {


### PR DESCRIPTION
Two small sentence-row rendering fixes.

Closes #41
Closes #29

## #41 — RTL sentence direction

**Symptom:** Arabic / Hebrew sentence rows rendered with token order flowing left-to-right while each token's characters flowed right-to-left, so the reading was wrong. (Plain text would be right-to-left, but our \`.token\`s are \`inline-block\` since the space-width feature, and that broke the row's bidi flow.)

**Fix:** the \`.words\` container now carries \`dir=getLocaleDirection(lang)\`, so when the sentence's language is RTL the whole row flows right-to-left and the inline-block tokens land in the right visual order.

\`getLocaleDirection\` itself only knew \`ar\` and \`fa\`. Extended to use \`Intl.Locale.prototype.getTextInfo\` (Chrome 109+ / FF 109+ / Safari 17+) so the platform tells us the direction for any BCP-47 tag, with a manual fallback list (\`ar fa he ur ps yi dv ks sd ckb\`) for older engines.

## #29 — Language tag wrapping

**Symptom:** long display names — \"印度尼西亚语\", \"Traditional Chinese\", etc. — could wrap into two lines next to a narrow sentence body.

**Fix:** \`white-space: nowrap\` on \`.tag\`.

## Diff
- \`src/lib/lang.ts\`: 17 added, 1 removed (broadened \`getLocaleDirection\`)
- \`src/lib/Output.svelte\`: 3 added, 1 removed (\`dir\` attribute + \`white-space: nowrap\`)

## Test plan
- [x] \`bun run check\` — 0 errors
- [ ] Load the **LTR · RTL** example: Arabic and Hebrew rows now read right-to-left as a whole; English row stays LTR
- [ ] Connector lines still line up correctly between LTR and RTL rows
- [ ] Switch the UI to a long-name locale (\`印度尼西亚语\`) — the tag column stays on one line
- [ ] Sanity: every existing non-RTL example still renders the same