### PR TITLE
feat(output): add Output Margin setting (Fixes #30)

### DIFF
--- a/project.inlang/messages/en.json
+++ b/project.inlang/messages/en.json
@@ -26,6 +26,7 @@
 	"params_font_size": "Font Size",
 	"params_gloss_font_size": "Gloss Font Size",
 	"params_space_width": "Space Width",
+	"params_output_margin": "Output Margin",
 	"input_input": "Input",
 	"input_placeholder": "Input new sentence here…",
 	"input_add": "Add",

--- a/src/i18n/i18n-svelte.ts
+++ b/src/i18n/i18n-svelte.ts
@@ -33,7 +33,8 @@ const createLL = () => ({
 		boldItalic: m.params_bold_italic,
 		fontSize: m.params_font_size,
 		glossFontSize: m.params_gloss_font_size,
-		spaceWidth: m.params_space_width
+		spaceWidth: m.params_space_width,
+		outputMargin: m.params_output_margin
 	},
 	input: {
 		input: m.input_input,

--- a/src/lib/Output.svelte
+++ b/src/lib/Output.svelte
@@ -65,6 +65,7 @@
 	export let fontSize: number;
 	export let glossFontSize: number;
 	export let spaceWidth: number;
+	export let outputMargin: number;
 	export let mode: Mode = 'view';
 
 	export let output: HTMLOutputElement;
@@ -370,6 +371,7 @@
 	class:bold={fontStyle === 'bold' || fontStyle === 'bold-italic'}
 	style:gap={`${verticalGap}px 1em`}
 	style:font-size={`${fontSize}px`}
+	style:padding={`${outputMargin}px`}
 >
 	{#if !loading}
 		{#each sentences as sentence, i}

--- a/src/lib/Parameters.svelte
+++ b/src/lib/Parameters.svelte
@@ -17,6 +17,7 @@
 	export let fontSize = 15;
 	export let glossFontSize = 11;
 	export let spaceWidth = 4;
+	export let outputMargin = 0;
 
 	$: lineGap = Math.min(lineGap, verticalGap / 2);
 	$: lineWidth = Math.max(0.1, lineWidth);
@@ -75,6 +76,12 @@
 		{$LL.params.curvature()}
 	</label>
 	<RangeSlider id="curvature" min={0} max={2} step={0.1} bind:value={curvature} suffix="x" />
+
+	<label for="output-margin">
+		<iconify-icon icon="mdi:border-outside" inline="true" />
+		{$LL.params.outputMargin()}
+	</label>
+	<RangeSlider id="output-margin" min={0} max={80} bind:value={outputMargin} suffix=" px" />
 </fieldset>
 
 <fieldset>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -89,6 +89,7 @@
 	let fontSize: number;
 	let glossFontSize = 11;
 	let spaceWidth = 4;
+	let outputMargin = 0;
 
 	let aboutOpen = false;
 
@@ -556,6 +557,7 @@
 					{fontSize}
 					{glossFontSize}
 					{spaceWidth}
+					{outputMargin}
 					{loading}
 					{modifying}
 					{editingSelectionStart}
@@ -653,6 +655,7 @@
 			bind:fontSize
 			bind:glossFontSize
 			bind:spaceWidth
+			bind:outputMargin
 		/>
 	</div>
 


### PR DESCRIPTION
Closes #30.

## What
A new \"Output Margin\" parameter (default 0 px, range 0–80) that pads the inside of the diagram container.

## Why
- **Display:** gives the connectors and end-most words some breathing space against the edge.
- **Exports:** \`dom-to-image\` captures the output's \`clientWidth\`/\`clientHeight\`, which include padding — so SVG / PNG / PDF exports automatically pick up the margin without any extra plumbing. Useful when embedding the diagram into a slide or a paper where the connectors would otherwise touch the page edge.

## UI
Slider lives in the Options fieldset, right after Curvature. Existing illustrations look identical at the default value of 0, so this is opt-in.

## i18n
One new key (\`params_output_margin\` = \"Output Margin\") in \`en.json\`. The other 31 locales fall back to English until translated in a follow-up.

## Diff
5 files, +15 / -1.

## Test plan
- [x] \`bun run check\` — 0 errors, 6 warnings (baseline)
- [x] \`bun x prettier --check\` on touched files — clean
- [ ] Slide Output Margin from 0 → 40 px → 80 px and back; diagram pads accordingly
- [ ] Export PNG / PDF at margin = 40 px → exported file has the margin baked in
- [ ] Default (margin = 0) renders the same as before

## Note on interpretation
The issue title is \"Add feature of margin setting\" with no description. The interpretation here is **padding inside the output container**, applied to both display and exports. If you meant CSS margin between sentence rows (use the existing \"Vertical Gap\"), or a separate export-only margin, let me know and I'll adjust.