### PR TITLE
docs: add related-tools comparison and first-publish date

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ For a guided tour, click the **Help** button in the header.
 | Author | [@mkpoli](https://github.com/mkpoli) | [Dani Polani](https://github.com/dani-polani) / [tinygodsdev](https://github.com/tinygodsdev) | [Jounlai Cho](https://github.com/jounlai) / [Heuron Corp.](https://heuron.com/) |
 | First public release | Aug 2022 | Apr 2026 | Mar 2026 |
 | Repo created | 2022-08-23 | 2026-04-18 | 2026-03-12 |
-| License | none in repo (see "[A note on rights](#a-note-on-rights)") | MIT | MIT (README only — no `LICENSE` file in repo) |
+| License | MIT (pending [#71](https://github.com/mkpoli/word-order/pull/71)) | MIT | MIT (README only — no `LICENSE` file in repo) |
 | GitHub stars (May 2026) | 13 | 1 | 5 |
 | Tech stack | SvelteKit 2 · Svelte 4 · TS · Vite 5 · Vercel | SvelteKit · Vite 8 · Docker | Static HTML/JS · D3 · no build |
 | Build step required | ✅ Vite | ✅ Vite | ❌ static files |

--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ For a guided tour, click the **Help** button in the header.
 
 ## Related tools
 
-> **TODO** — this section is a working draft. Verify each tool's current feature set and add missing peers before publishing externally.
+> **TODO** — this section is a working draft. Re-verify each tool's current feature set before relying on the comparison externally; add any peers that are missing.
 
 ### Authoring tools (closest peers — manual click-to-link alignment with curved connectors)
 
-- **[Bitext Align](https://aligner.tinygods.dev/)** ([source](https://github.com/tinygodsdev/bitext-word-alignment)) — SvelteKit. Multi-line editor with per-line LTR/RTL, gloss/IPA tiers, PNG/SVG/PDF/HTML export, URL-encoded share, light/dark theme, 3 built-in examples.
+- **[Bitext Align](https://aligner.tinygods.dev/)** ([source](https://github.com/tinygodsdev/bitext-word-alignment)) — SvelteKit. By [Dani Polani](https://github.com/dani-polani) under the [tinygodsdev](https://github.com/tinygodsdev) org. Multi-line editor with per-line LTR/RTL, gloss/IPA tiers, PNG/SVG/PDF/HTML export, URL-encoded share, light/dark theme, 3 built-in examples.
 - **[BasicCAT Bitext Aligner](https://www.basiccat.org/new-tool-bitext-aligner/)** — sentence/word aligner shipped inside a CAT translation suite.
 - **Academic prototypes** (paper-only, not always hosted):
   - **Yawat** — uses dynamic markup to keep the alignment view from getting visually busy as connections pile up.
@@ -70,38 +70,71 @@ For a guided tour, click the **Help** button in the header.
 
 ### Feature comparison
 
-> **TODO** — checkmarks below reflect a quick survey in May 2026. Re-verify against each tool's current release before relying on them.
+> **TODO** — survey conducted May 2026 from each tool's then-current live build, GitHub repo, and README. Cells marked `?` were not directly verifiable from the public surface and should be confirmed by the tool's author before being cited externally.
+
+#### Identity & metadata
+
+| | Word Order Illustrator | Bitext Align | LangMap |
+|---|---|---|---|
+| Category | Authoring | Authoring | Curated atlas |
+| Web | [word-order.mkpo.li](https://word-order.mkpo.li/) | [aligner.tinygods.dev](https://aligner.tinygods.dev/) | [langmap.heuron.com](https://langmap.heuron.com/) |
+| Repo | [mkpoli/word-order](https://github.com/mkpoli/word-order) | [tinygodsdev/bitext-word-alignment](https://github.com/tinygodsdev/bitext-word-alignment) | [jounlai/langmap](https://github.com/jounlai/langmap) |
+| Author | [@mkpoli](https://github.com/mkpoli) | [Dani Polani](https://github.com/dani-polani) / [tinygodsdev](https://github.com/tinygodsdev) | [Jounlai Cho](https://github.com/jounlai) / [Heuron Corp.](https://heuron.com/) |
+| First public release | Aug 2022 | Apr 2026 | Mar 2026 |
+| Repo created | 2022-08-23 | 2026-04-18 | 2026-03-12 |
+| License | none in repo (see "[A note on rights](#a-note-on-rights)") | MIT | MIT (README only — no `LICENSE` file in repo) |
+| GitHub stars (May 2026) | 13 | 1 | 5 |
+| Tech stack | SvelteKit 2 · Svelte 4 · TS · Vite 5 · Vercel | SvelteKit · Vite 8 · Docker | Static HTML/JS · D3 · no build |
+| Build step required | ✅ Vite | ✅ Vite | ❌ static files |
+
+#### Alignment authoring
 
 | Feature | Word Order Illustrator | Bitext Align | LangMap |
 |---|---|---|---|
-| Author | [@mkpoli](https://github.com/mkpoli) | [tinygodsdev](https://github.com/tinygodsdev) | [Jounlai Cho](https://github.com/jounlai) / [Heuron Corp.](https://heuron.com/) |
-| Web | [word-order.mkpo.li](https://word-order.mkpo.li/) | [aligner.tinygods.dev](https://aligner.tinygods.dev/) | [langmap.heuron.com](https://langmap.heuron.com/) |
-| Repo | [mkpoli/word-order](https://github.com/mkpoli/word-order) | [tinygodsdev/bitext-word-alignment](https://github.com/tinygodsdev/bitext-word-alignment) | [jounlai/langmap](https://github.com/jounlai/langmap) |
-| Tech stack | SvelteKit 2 · Svelte 4 · TS · Vite 5 · Vercel | SvelteKit · Vite 8 · Docker | Static HTML/JS · D3 · no build |
-| Category | Authoring | Authoring | Curated atlas |
-| First public release | Aug 2022 | TBD | TBD |
-| License | (TBD — repo) | (TBD) | MIT |
 | Manual click-to-link alignment | ✅ | ✅ | n/a (pre-aligned) |
 | Curved Bézier connectors | ✅ tunable | ✅ tunable | ✅ |
+| Connector parameters exposed | curvature, line width, gap, straight length, endpoint correction | style, colors, tokens, fonts | minimal |
 | `Intl.Segmenter` tokenization (CJK / Thai) | ✅ | ❌ whitespace + manual join | n/a |
 | `<ruby>` (furigana / pinyin / zhuyin) | ✅ tokens & glosses | ❌ | ❌ |
-| Interlinear gloss tier | ✅ | ✅ | ❌ |
+| Interlinear gloss tier | ✅ | ✅ extra tier | ❌ |
 | Per-token merge / split dialog | ✅ | partial | ❌ |
 | Per-line RTL / LTR toggle | implicit (BCP-47) | ✅ explicit | ✅ |
 | Multiple sentences (> 2 rows) | ✅ | ✅ | ✅ |
 | Drag to reorder rows | ✅ | ✅ | ✅ |
+| Delete row | ✅ | ✅ | ✅ |
+| Reorder color groups | ✅ | ? | n/a |
 | Scramble equivalency view | ✅ | ❌ | ❌ |
 | LLM translate + auto-align (BYO key) | ✅ | ❌ | ❌ |
-| Built-in examples | 10+ | 3 | 100 |
+
+#### Content & presentation
+
+| Feature | Word Order Illustrator | Bitext Align | LangMap |
+|---|---|---|---|
+| Built-in examples | 10+ | 3 | 100 sentences × 223 langs |
 | UI languages | 32 | 1 (EN) | 21 |
 | Light / dark theme | ❌ | ✅ | ✅ |
+| Font customization | ✅ family / style / size | ✅ Fonts panel | font size only |
+| Color palette customization | ✅ OKLCH auto + Settings | ✅ Colors panel | ❌ fixed |
+| Language metadata (family / typology / IPA) | ❌ | ❌ | ✅ extensive |
+| Mobile responsive | ? | ? | ✅ |
+| Keyboard navigation | ? | ? | ✅ arrow keys, random |
+| Guided tour / Help | ✅ (Help button) | ❌ | ❌ |
+
+#### Persistence & sharing
+
+| Feature | Word Order Illustrator | Bitext Align | LangMap |
+|---|---|---|---|
+| Autosave (localStorage) | ✅ | ? | n/a |
+| Multiple workspaces / tabs | ✅ (per-tab autosave) | ❌ | n/a |
 | URL share (state in hash) | ❌ | ✅ | ✅ |
-| Export SVG | ✅ | ✅ | ✅ |
+| Social share buttons | ❌ | ✅ | ✅ X / Facebook / LINE |
+| Export SVG | ✅ vector | ✅ vector | ✅ |
 | Export PNG | ✅ (2× fixed) | ✅ (2×–6× picker) | ✅ |
 | Export PDF | ✅ | ✅ | ❌ |
 | Export HTML | ❌ | ✅ | ❌ |
 | Export JSON (project archive) | ✅ | ❌ | ❌ |
-| Language metadata (family / typology) | ❌ | ❌ | ✅ |
+| Export CSV | ❌ | ❌ | ✅ |
+| SEO (OG image, JSON-LD) | ✅ | ❌ | ❌ |
 
 ## Developing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > A bitext word-alignment and word-order illustrator for translators, language learners, conlangers, and linguists.
 
-**Live demo:** <https://word-order.mkpo.li/>
+**Live demo:** <https://word-order.mkpo.li/> · **First published:** August 2022
 
 ![Preview of the Word Order Illustrator with linked words across two languages.](static/og-image.png)
 
@@ -42,6 +42,66 @@ For a guided tour, click the **Help** button in the header.
 - [`colorjs.io`](https://colorjs.io/) for OKLCH color palette generation
 - [Iconify](https://iconify.design/) for icons
 - Deployed on [Vercel](https://vercel.com/)
+
+## Related tools
+
+> **TODO** — this section is a working draft. Verify each tool's current feature set and add missing peers before publishing externally.
+
+### Authoring tools (closest peers — manual click-to-link alignment with curved connectors)
+
+- **[Bitext Align](https://aligner.tinygods.dev/)** ([source](https://github.com/tinygodsdev/bitext-word-alignment)) — SvelteKit. Multi-line editor with per-line LTR/RTL, gloss/IPA tiers, PNG/SVG/PDF/HTML export, URL-encoded share, light/dark theme, 3 built-in examples.
+- **[BasicCAT Bitext Aligner](https://www.basiccat.org/new-tool-bitext-aligner/)** — sentence/word aligner shipped inside a CAT translation suite.
+- **Academic prototypes** (paper-only, not always hosted):
+  - **Yawat** — uses dynamic markup to keep the alignment view from getting visually busy as connections pile up.
+  - **[Line-a-line](https://www.academia.edu/49114010/)** — drag-and-drop alignment for under-resourced parallel corpora.
+  - **CLUE-Aligner** — manual annotation of contiguous and non-contiguous multiword expressions.
+  - **[SWIFT Aligner](https://www.researchgate.net/publication/263765021)** — visualization + alignment + morpho-syntactic cross-language transfer in one GUI.
+
+### Curated atlases (browse pre-aligned data — not for authoring your own)
+
+- **[LangMap](https://langmap.heuron.com/)** ([source](https://github.com/jounlai/langmap)) — 100 sentences × 223 languages of hand-aligned word-order data, plus a 957-language word atlas with IPA and a D3 family tree.
+
+### Interlinear gloss formatters (adjacent category — they typeset glosses, they don't align across rows)
+
+- **[Leipzig.js](https://bdchauvette.net/leipzig.js/)** ([source](https://github.com/bdchauvette/leipzig.js/)) — JS library for embedding Leipzig-style glosses in HTML.
+- **[Gloss My Gloss](https://neonnaut.github.io/)** — browser tool that formats glosses into aligned columns with abbreviation tooltips.
+- **[leipzig-glossing (Typst)](https://typst.app/universe/package/leipzig-glossing/)** — Typst package for typesetting glosses in documents.
+- **[FieldWorks Language Explorer](https://software.sil.org/fieldworks/)** — SIL's desktop suite for full interlinear text annotation with a persistent lexicon.
+
+### Feature comparison
+
+> **TODO** — checkmarks below reflect a quick survey in May 2026. Re-verify against each tool's current release before relying on them.
+
+| Feature | Word Order Illustrator | Bitext Align | LangMap |
+|---|---|---|---|
+| Author | [@mkpoli](https://github.com/mkpoli) | [tinygodsdev](https://github.com/tinygodsdev) | [Jounlai Cho](https://github.com/jounlai) / [Heuron Corp.](https://heuron.com/) |
+| Web | [word-order.mkpo.li](https://word-order.mkpo.li/) | [aligner.tinygods.dev](https://aligner.tinygods.dev/) | [langmap.heuron.com](https://langmap.heuron.com/) |
+| Repo | [mkpoli/word-order](https://github.com/mkpoli/word-order) | [tinygodsdev/bitext-word-alignment](https://github.com/tinygodsdev/bitext-word-alignment) | [jounlai/langmap](https://github.com/jounlai/langmap) |
+| Tech stack | SvelteKit 2 · Svelte 4 · TS · Vite 5 · Vercel | SvelteKit · Vite 8 · Docker | Static HTML/JS · D3 · no build |
+| Category | Authoring | Authoring | Curated atlas |
+| First public release | Aug 2022 | TBD | TBD |
+| License | (TBD — repo) | (TBD) | MIT |
+| Manual click-to-link alignment | ✅ | ✅ | n/a (pre-aligned) |
+| Curved Bézier connectors | ✅ tunable | ✅ tunable | ✅ |
+| `Intl.Segmenter` tokenization (CJK / Thai) | ✅ | ❌ whitespace + manual join | n/a |
+| `<ruby>` (furigana / pinyin / zhuyin) | ✅ tokens & glosses | ❌ | ❌ |
+| Interlinear gloss tier | ✅ | ✅ | ❌ |
+| Per-token merge / split dialog | ✅ | partial | ❌ |
+| Per-line RTL / LTR toggle | implicit (BCP-47) | ✅ explicit | ✅ |
+| Multiple sentences (> 2 rows) | ✅ | ✅ | ✅ |
+| Drag to reorder rows | ✅ | ✅ | ✅ |
+| Scramble equivalency view | ✅ | ❌ | ❌ |
+| LLM translate + auto-align (BYO key) | ✅ | ❌ | ❌ |
+| Built-in examples | 10+ | 3 | 100 |
+| UI languages | 32 | 1 (EN) | 21 |
+| Light / dark theme | ❌ | ✅ | ✅ |
+| URL share (state in hash) | ❌ | ✅ | ✅ |
+| Export SVG | ✅ | ✅ | ✅ |
+| Export PNG | ✅ (2× fixed) | ✅ (2×–6× picker) | ✅ |
+| Export PDF | ✅ | ✅ | ❌ |
+| Export HTML | ❌ | ✅ | ❌ |
+| Export JSON (project archive) | ✅ | ❌ | ❌ |
+| Language metadata (family / typology) | ❌ | ❌ | ✅ |
 
 ## Developing
 


### PR DESCRIPTION
## Summary

- Adds a **Related tools** section to `README.md`, grouped into:
  - **Authoring peers** (closest category) — [Bitext Align](https://aligner.tinygods.dev/), [BasicCAT Bitext Aligner](https://www.basiccat.org/new-tool-bitext-aligner/), plus academic prototypes (Yawat, [Line-a-line](https://www.academia.edu/49114010/), CLUE-Aligner, [SWIFT Aligner](https://www.researchgate.net/publication/263765021))
  - **Curated atlases** — [LangMap](https://langmap.heuron.com/)
  - **Interlinear gloss formatters** (adjacent category) — [Leipzig.js](https://bdchauvette.net/leipzig.js/), [Gloss My Gloss](https://neonnaut.github.io/), [leipzig-glossing (Typst)](https://typst.app/universe/package/leipzig-glossing/), [FieldWorks](https://software.sil.org/fieldworks/)
- Adds a **feature comparison table** with author / web / repo / tech-stack metadata rows on top of ~20 feature rows for the three closest peers (this project, Bitext Align, LangMap).
- Annotates the live-demo line with `First published: August 2022`.

## TODOs flagged in-page

Both the prose list and the table carry explicit `> **TODO**` callouts so the comparison is not treated as authoritative:
- Verify each tool's current feature set against its latest release.
- Fill in `TBD` cells (first-release date for Bitext Align and LangMap, license columns).
- Add any missing peers I missed in this pass.

## Test plan

- [x] Render `README.md` on GitHub and confirm the table layout doesn't wrap awkwardly on mobile.
- [x] Spot-check a few of the external links resolve.
- [x] Confirm "August 2022" matches the actual first-deploy timestamp (initial commit is 2022-08-23).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with initial publication date
  * Added new "Related tools" section featuring categorized links to complementary tools
  * Introduced comprehensive feature comparison table showcasing tool capabilities across alignment authoring, content presentation, and data persistence

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mkpoli/word-order/pull/62?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->