### PR TITLE
chore: add MIT LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022-2026 mkpoli
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ Issues and pull requests welcome at <https://github.com/mkpoli/word-order/>.
 
 Created by [@mkpoli](https://mkpo.li/) — [Twitter](https://twitter.com/mkpoli/) · [GitHub](https://github.com/mkpoli).
 
-## A note on rights
+## License
+
+Source code is released under the [MIT License](LICENSE) © 2022–2026 mkpoli.
+
+### A note on rights
 
 This application doesn't claim rights over the illustrations you create with it. How you use or share them is entirely up to you. Sharing the tool itself is appreciated.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
 	"name": "word-order",
 	"version": "0.0.1",
 	"private": true,
+	"license": "MIT",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",


### PR DESCRIPTION
## Summary

The repo had no \`LICENSE\` file, which made the source code "all rights reserved" by default under copyright law — directly contradicting the README's "Issues and pull requests welcome" line, since contributors had no legal basis to submit derivative work.

This PR fixes that by adding a standard MIT LICENSE © 2022–2026 mkpoli — matching the license choice of both peer tools ([Bitext Align](https://github.com/tinygodsdev/bitext-word-alignment) and [LangMap](https://github.com/jounlai/langmap)).

## Changes

- New \`LICENSE\` file (standard MIT, ~200 words).
- \`package.json\`: adds \`"license": "MIT"\` field next to other top-level metadata.
- \`README.md\`: adds a \`## License\` section linking to the new file. The existing "A note on rights" paragraph (which covers user-generated *output*, not source code) is preserved as a subsection under it — outputs remain unencumbered and the "sharing the tool is appreciated" line stays.

## Follow-up

Once this lands, the comparison table in #62 (currently says "none in repo" for our license cell) should be updated to "MIT". Happy to roll that into a follow-up commit on that branch.

## Test plan

- [ ] GitHub picks up the LICENSE file and shows "MIT" in the repo sidebar.
- [ ] \`bun run check\` still passes (license field is metadata, no code paths touched).
- [ ] README renders the new License section correctly with working LICENSE link.