### PR TITLE
docs: polish README — accurate features, BYO translate, cleaner shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,16 @@ Paste sentences in any languages, click matching words across rows, and the tool
 
 ## Features
 
-- **Locale-aware tokenization** — CJK, Thai, and other unspaced scripts are auto-segmented; use `|` to fix the cases where the segmenter guesses wrong.
-- **Curved connectors** with tunable curvature, line width, gap, and endpoint correction.
-- **Multi-tier annotations above and below each word** — gloss, IPA, morphemes, as many tiers as you need.
-- **Ruby annotations** (`<ruby>漢<rt>かん</rt></ruby>`) render inline in source text and in any annotation tier.
-- **Per-token merge and split** at any grapheme boundary.
-- **Scramble equivalency** — one click reorders the color groups to show how much a translation reshuffles meaning.
-- **BYO-key LLM translate-and-align** — supply your own [OpenAI](https://platform.openai.com/), [Anthropic](https://console.anthropic.com/), or [Gemini](https://aistudio.google.com/app/apikey) key (stored only in localStorage). Translate into one or more targets at once with auto-glossing and auto-alignment; any BCP-47 code works as a target.
-- **Examples gallery** — SOV vs SVO, RTL scripts, Romance pro-drop, multi-script CJK, Turkish interlinear gloss, Ainu polysynthesis, Genesis 1:1 across Hebrew / Koine Greek / Latin / English, and more.
-- **localStorage autosave** and **export** as SVG, PNG, PDF, or re-importable JSON.
-- **UI in 30+ languages** via [Paraglide](https://inlang.com/m/gerre34r/library-inlang-paraglideJs) — including Ainu, Korean Hanja, Esperanto, Interlingua, and Toki Pona.
+- 🔤 **Locale-aware tokenization** — CJK, Thai, and other unspaced scripts are auto-segmented; use `|` to fix the cases where the segmenter guesses wrong.
+- 〰️ **Curved connectors** with tunable curvature, line width, gap, and endpoint correction.
+- 🏷️ **Multi-tier annotations above and below each word** — gloss, IPA, morphemes, as many tiers as you need.
+- 🈁 **Ruby annotations** (`<ruby>漢<rt>かん</rt></ruby>`) render inline in source text and in any annotation tier.
+- ✂️ **Per-token merge and split** at any grapheme boundary.
+- 🎲 **Scramble equivalency** — one click reorders the color groups to show how much a translation reshuffles meaning.
+- 🤖 **BYO-key LLM translate-and-align** — supply your own [OpenAI](https://platform.openai.com/), [Anthropic](https://console.anthropic.com/), or [Gemini](https://aistudio.google.com/app/apikey) key (stored only in localStorage). Translate into one or more targets at once with auto-glossing and auto-alignment; any BCP-47 code works as a target.
+- 📚 **Examples gallery** — SOV vs SVO, RTL scripts, Romance pro-drop, multi-script CJK, Turkish interlinear gloss, Ainu polysynthesis, Genesis 1:1 across Hebrew / Koine Greek / Latin / English, and more.
+- 💾 **localStorage autosave** and **export** as SVG, PNG, PDF, or re-importable JSON.
+- 🌐 **UI in 30+ languages** via [Paraglide](https://inlang.com/m/gerre34r/library-inlang-paraglideJs) — including Ainu, Korean Hanja, Esperanto, Interlingua, and Toki Pona.
 
 ## How to use
 

--- a/README.md
+++ b/README.md
@@ -15,45 +15,43 @@ Paste sentences in any languages, click matching words across rows, and the tool
 - **Conlangers** showing off word order, agglutination, or polypersonal agreement.
 - **Linguists and teachers** preparing Leipzig-style interlinear handouts and slides.
 
-## Features
+## What you can do
 
-### Editor & rendering
+### Build the alignment
 
-- **Locale-aware tokenization** via `Intl.Segmenter` — CJK, Thai, and other unspaced scripts split correctly out of the box. Use `|` for finer manual control.
-- **Curved connectors** with adjustable curvature, line width, gap, straight segments, and endpoint correction.
-- **Multi-tier annotations** — stack any number of gloss / IPA / morpheme lines **above and below** each word for full Leipzig-style displays.
-- **Ruby annotations** — `<ruby>漢<rt>かん</rt></ruby>` works inside both sentence text and glosses, so furigana, pinyin, and zhuyin render correctly.
-- **Per-token edit dialog** — merge selected tokens, split at any grapheme boundary, or merge into a neighbor.
-- **Figma-style per-side margin control** — adjust top, right, bottom, and left padding of the canvas independently for tight social-share crops.
-- **Scramble equivalency** — instantly reorder the color groups to visualize how often translations rearrange information.
+- **Paste text in any language and it just splits correctly** — Chinese, Japanese, Thai, and other space-free scripts get tokenized automatically. Use `|` if you want to override where a word starts or ends.
+- **Click matching words across rows** to draw curved connectors between them. One-to-many, many-to-one, and crossing lines all stay readable.
+- **Mix any number of scripts and directions** — LTR and RTL rows happily sit next to each other; mid-row script changes work too.
+- **Split or merge any token down to the character** when the automatic segmentation doesn't match how you want to align.
 
-### Translation assistance (BYO key)
+### Annotate
 
-- **LLM translate-and-align** — bring your own [OpenAI](https://platform.openai.com/), [Anthropic](https://console.anthropic.com/), or [Google Gemini](https://aistudio.google.com/app/apikey) key (stored only in your browser's localStorage, never sent anywhere except the chosen provider).
-- **Multi-target in one call** — pick one or more target languages and the tool requests parallel translations, fills in interlinear glosses for each new row, and auto-connects matching tokens across rows by gloss bucket.
-- **Custom target codes** — accepts any BCP-47 tag, so conlangs and rare locales work too.
-- **Configurable provider + model** in the Settings dialog, with a combobox of suggested model IDs.
+- **Stack as many annotation lines as you want above or below each word** — pinyin on top, IPA below, gloss below that, a morpheme breakdown next to it. Leipzig-style displays come naturally.
+- **Add furigana, pinyin, or zhuyin** using `<ruby>` markup inline — works inside both the source text and any annotation tier.
 
-### Persistence, examples, export
+### Translate without leaving the app *(bring your own API key)*
 
-- **localStorage autosave** — refreshing or closing the browser preserves your work.
-- **Examples gallery** — SOV vs SVO, RTL scripts, Romance pro-drop, multi-script CJK, Turkish interlinear gloss, Ainu polysynthesis, Genesis 1:1 across Hebrew / Koine Greek / Latin / English, and more.
-- **About dialog** with attribution, links, and version info.
-- **Export** as SVG (vector), PNG (raster), PDF, or full project JSON for archival and sharing. Filenames are auto-generated from the first row's text and locale list.
+- **Generate a translation row in one click** using your own [OpenAI](https://platform.openai.com/), [Anthropic](https://console.anthropic.com/), or [Google Gemini](https://aistudio.google.com/app/apikey) key. Keys live only in your browser's localStorage and are sent only to the provider you chose.
+- **Translate into several target languages at once** — pick a list and the rows come back in parallel.
+- **Glosses are filled in automatically**, and matching tokens across the new rows are pre-connected by their shared gloss so you can start refining instead of clicking from scratch.
+- **Any BCP-47 code works as a target**, so conlangs and rare locales aren't blocked by what the model lists.
 
-### Localization & SEO
+### Compare and export
 
-- **UI in 30+ languages** via [Paraglide](https://inlang.com/m/gerre34r/library-inlang-paraglideJs) — including Ainu, Korean Hanja, Bulgarian, Finnish, Esperanto, Interlingua, Toki Pona, and more.
-- **SEO-ready** with localized metadata, Open Graph, JSON-LD, and an Open Graph preview image.
+- **Hit "Scramble"** to randomly reorder the color groups — a one-button way to show students how much a translation reshuffles meaning.
+- **Load a ready-made illustration** from the Examples menu — SOV vs SVO, RTL scripts, Romance pro-drop, multi-script CJK, Turkish interlinear gloss, Ainu polysynthesis, Genesis 1:1 across Hebrew / Koine Greek / Latin / English, and more.
+- **Your work is saved automatically** — refreshing or closing the tab won't lose it.
+- **Export as SVG, PNG, PDF, or a JSON project file.** The JSON re-imports later for archival and sharing. Filenames are auto-named after the first row's text and the language list.
+- **Switch the app's UI between 30+ languages** — including Ainu, Korean Hanja, Esperanto, Interlingua, and Toki Pona.
 
 ## How to use
 
-1. Type or paste a sentence into the input box and press **Add**. Words are split automatically using locale-aware segmentation.
-2. *(Optional, BYO key)* Click **Translate** to pick one or more target languages — the tool generates rows, glosses, and tentative alignments in one go.
-3. Click a word in one row, then a matching word in an adjacent row, and press **Confirm** to connect them. Click an already-linked word to edit its color group.
-4. Use the pencil icon on any row to fine-tune tokenization (merge/split tokens) and to add or rearrange annotation tiers above and below.
-5. Adjust spacing, curvature, fonts, per-side margins, and text alignment in the **Options** panel.
-6. Export as SVG, PNG, PDF, or JSON from the **Export** menu — or load a ready-made illustration from **Examples**.
+1. Type or paste a sentence into the input box and press **Add**.
+2. *(Optional)* If you've added an API key in **Settings**, click **Translate** to pick target languages — the tool fills in translated rows, glosses, and tentative alignments for you.
+3. Click a word in one row, then a matching word in another, and press **Confirm** to connect them. Clicking an already-linked word lets you edit its color group.
+4. Use the pencil icon on any row to fine-tune tokenization or add annotation tiers above and below.
+5. Tweak spacing, curvature, fonts, and text alignment in the **Options** panel.
+6. Export from the **Export** menu — or load a ready-made example from **Examples**.
 
 ## Tech stack
 

--- a/README.md
+++ b/README.md
@@ -8,41 +8,18 @@
 
 Paste sentences in any languages, click matching words across rows, and the tool draws curved connectors. Reordered translations, one-to-many mappings, and many-to-one mappings all stay readable.
 
-## Who is it for?
+## Features
 
-- **Translators** documenting how phrasing reshuffles across a pair.
-- **Language learners** seeing where their L1 intuition diverges from a new language.
-- **Conlangers** showing off word order, agglutination, or polypersonal agreement.
-- **Linguists and teachers** preparing Leipzig-style interlinear handouts and slides.
-
-## What you can do
-
-### Build the alignment
-
-- **Paste text in any language and it just splits correctly** — Chinese, Japanese, Thai, and other space-free scripts get tokenized automatically. Use `|` if you want to override where a word starts or ends.
-- **Click matching words across rows** to draw curved connectors between them. One-to-many, many-to-one, and crossing lines all stay readable.
-- **Mix any number of scripts and directions** — LTR and RTL rows happily sit next to each other; mid-row script changes work too.
-- **Split or merge any token down to the character** when the automatic segmentation doesn't match how you want to align.
-
-### Annotate
-
-- **Stack as many annotation lines as you want above or below each word** — pinyin on top, IPA below, gloss below that, a morpheme breakdown next to it. Leipzig-style displays come naturally.
-- **Add furigana, pinyin, or zhuyin** using `<ruby>` markup inline — works inside both the source text and any annotation tier.
-
-### Translate without leaving the app *(bring your own API key)*
-
-- **Generate a translation row in one click** using your own [OpenAI](https://platform.openai.com/), [Anthropic](https://console.anthropic.com/), or [Google Gemini](https://aistudio.google.com/app/apikey) key. Keys live only in your browser's localStorage and are sent only to the provider you chose.
-- **Translate into several target languages at once** — pick a list and the rows come back in parallel.
-- **Glosses are filled in automatically**, and matching tokens across the new rows are pre-connected by their shared gloss so you can start refining instead of clicking from scratch.
-- **Any BCP-47 code works as a target**, so conlangs and rare locales aren't blocked by what the model lists.
-
-### Compare and export
-
-- **Hit "Scramble"** to randomly reorder the color groups — a one-button way to show students how much a translation reshuffles meaning.
-- **Load a ready-made illustration** from the Examples menu — SOV vs SVO, RTL scripts, Romance pro-drop, multi-script CJK, Turkish interlinear gloss, Ainu polysynthesis, Genesis 1:1 across Hebrew / Koine Greek / Latin / English, and more.
-- **Your work is saved automatically** — refreshing or closing the tab won't lose it.
-- **Export as SVG, PNG, PDF, or a JSON project file.** The JSON re-imports later for archival and sharing. Filenames are auto-named after the first row's text and the language list.
-- **Switch the app's UI between 30+ languages** — including Ainu, Korean Hanja, Esperanto, Interlingua, and Toki Pona.
+- **Locale-aware tokenization** — CJK, Thai, and other unspaced scripts split correctly; use `|` to override.
+- **Curved connectors** with tunable curvature, line width, gap, and endpoint correction.
+- **Multi-tier annotations above and below each word** — gloss, IPA, morphemes, as many tiers as you need.
+- **Ruby annotations** (`<ruby>漢<rt>かん</rt></ruby>`) render inline in source text and in any annotation tier.
+- **Per-token merge and split** at any grapheme boundary.
+- **Scramble equivalency** — one click reorders the color groups to show how much a translation reshuffles meaning.
+- **BYO-key LLM translate-and-align** — supply your own [OpenAI](https://platform.openai.com/), [Anthropic](https://console.anthropic.com/), or [Gemini](https://aistudio.google.com/app/apikey) key (stored only in localStorage). Translate into one or more targets at once with auto-glossing and auto-alignment; any BCP-47 code works as a target.
+- **Examples gallery** — SOV vs SVO, RTL scripts, Romance pro-drop, multi-script CJK, Turkish interlinear gloss, Ainu polysynthesis, Genesis 1:1 across Hebrew / Koine Greek / Latin / English, and more.
+- **localStorage autosave** and **export** as SVG, PNG, PDF, or re-importable JSON.
+- **UI in 30+ languages** via [Paraglide](https://inlang.com/m/gerre34r/library-inlang-paraglideJs) — including Ainu, Korean Hanja, Esperanto, Interlingua, and Toki Pona.
 
 ## How to use
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Paste sentences in any languages, click matching words across rows, and the tool
 
 ## Features
 
-- **Locale-aware tokenization** — CJK, Thai, and other unspaced scripts split correctly; use `|` to override.
+- **Locale-aware tokenization** — CJK, Thai, and other unspaced scripts are auto-segmented; use `|` to fix the cases where the segmenter guesses wrong.
 - **Curved connectors** with tunable curvature, line width, gap, and endpoint correction.
 - **Multi-tier annotations above and below each word** — gloss, IPA, morphemes, as many tiers as you need.
 - **Ruby annotations** (`<ruby>漢<rt>かん</rt></ruby>`) render inline in source text and in any annotation tier.

--- a/README.md
+++ b/README.md
@@ -8,29 +8,52 @@
 
 Paste sentences in any languages, click matching words across rows, and the tool draws curved connectors. Reordered translations, one-to-many mappings, and many-to-one mappings all stay readable.
 
+## Who is it for?
+
+- **Translators** documenting how phrasing reshuffles across a pair.
+- **Language learners** seeing where their L1 intuition diverges from a new language.
+- **Conlangers** showing off word order, agglutination, or polypersonal agreement.
+- **Linguists and teachers** preparing Leipzig-style interlinear handouts and slides.
+
 ## Features
+
+### Editor & rendering
 
 - **Locale-aware tokenization** via `Intl.Segmenter` — CJK, Thai, and other unspaced scripts split correctly out of the box. Use `|` for finer manual control.
 - **Curved connectors** with adjustable curvature, line width, gap, straight segments, and endpoint correction.
-- **Interlinear gloss** row above each sentence for Leipzig-style annotations.
+- **Multi-tier annotations** — stack any number of gloss / IPA / morpheme lines **above and below** each word for full Leipzig-style displays.
 - **Ruby annotations** — `<ruby>漢<rt>かん</rt></ruby>` works inside both sentence text and glosses, so furigana, pinyin, and zhuyin render correctly.
 - **Per-token edit dialog** — merge selected tokens, split at any grapheme boundary, or merge into a neighbor.
-- **Multiple projects via tabs** with localStorage autosave — refreshing or closing the browser preserves your work.
-- **Examples gallery** — SOV vs SVO, RTL scripts, Romance pro-drop, multi-script CJK, Turkish interlinear gloss, Genesis 1:1 across Hebrew / Koine Greek / Latin / English.
+- **Figma-style per-side margin control** — adjust top, right, bottom, and left padding of the canvas independently for tight social-share crops.
 - **Scramble equivalency** — instantly reorder the color groups to visualize how often translations rearrange information.
-- **Export** as SVG (vector) or PNG (raster), plus full project JSON for archival and sharing.
-- **UI in 20+ languages** via [Paraglide](https://inlang.com/m/gerre34r/library-inlang-paraglideJs) — including Ainu, Korean Hanja, Bulgarian, Finnish, Esperanto, Interlingua, Toki Pona, and more.
+
+### Translation assistance (BYO key)
+
+- **LLM translate-and-align** — bring your own [OpenAI](https://platform.openai.com/), [Anthropic](https://console.anthropic.com/), or [Google Gemini](https://aistudio.google.com/app/apikey) key (stored only in your browser's localStorage, never sent anywhere except the chosen provider).
+- **Multi-target in one call** — pick one or more target languages and the tool requests parallel translations, fills in interlinear glosses for each new row, and auto-connects matching tokens across rows by gloss bucket.
+- **Custom target codes** — accepts any BCP-47 tag, so conlangs and rare locales work too.
+- **Configurable provider + model** in the Settings dialog, with a combobox of suggested model IDs.
+
+### Persistence, examples, export
+
+- **localStorage autosave** — refreshing or closing the browser preserves your work.
+- **Examples gallery** — SOV vs SVO, RTL scripts, Romance pro-drop, multi-script CJK, Turkish interlinear gloss, Ainu polysynthesis, Genesis 1:1 across Hebrew / Koine Greek / Latin / English, and more.
+- **About dialog** with attribution, links, and version info.
+- **Export** as SVG (vector), PNG (raster), PDF, or full project JSON for archival and sharing. Filenames are auto-generated from the first row's text and locale list.
+
+### Localization & SEO
+
+- **UI in 30+ languages** via [Paraglide](https://inlang.com/m/gerre34r/library-inlang-paraglideJs) — including Ainu, Korean Hanja, Bulgarian, Finnish, Esperanto, Interlingua, Toki Pona, and more.
 - **SEO-ready** with localized metadata, Open Graph, JSON-LD, and an Open Graph preview image.
 
 ## How to use
 
 1. Type or paste a sentence into the input box and press **Add**. Words are split automatically using locale-aware segmentation.
-2. Click a word in one row, then a matching word in an adjacent row, then press **Confirm** to connect them. Click an already-linked word to edit its color group.
-3. Use the pencil icon to fine-tune tokenization (merge/split tokens) and optionally fill in an interlinear gloss row.
-4. Adjust spacing, curvature, fonts, and text alignment in the Options panel.
-5. Export as SVG or PNG when you're done.
-
-For a guided tour, click the **Help** button in the header.
+2. *(Optional, BYO key)* Click **Translate** to pick one or more target languages — the tool generates rows, glosses, and tentative alignments in one go.
+3. Click a word in one row, then a matching word in an adjacent row, and press **Confirm** to connect them. Click an already-linked word to edit its color group.
+4. Use the pencil icon on any row to fine-tune tokenization (merge/split tokens) and to add or rearrange annotation tiers above and below.
+5. Adjust spacing, curvature, fonts, per-side margins, and text alignment in the **Options** panel.
+6. Export as SVG, PNG, PDF, or JSON from the **Export** menu — or load a ready-made illustration from **Examples**.
 
 ## Tech stack
 
@@ -45,7 +68,7 @@ For a guided tour, click the **Help** button in the header.
 
 ## Related tools
 
-> **TODO** — this section is a working draft. Re-verify each tool's current feature set before relying on the comparison externally; add any peers that are missing.
+> Working draft — re-verify each tool's current feature set before citing the comparison externally; add any peers that are missing.
 
 ### Authoring tools (closest peers — manual click-to-link alignment with curved connectors)
 
@@ -70,7 +93,10 @@ For a guided tour, click the **Help** button in the header.
 
 ### Feature comparison
 
-> **TODO** — survey conducted May 2026 from each tool's then-current live build, GitHub repo, and README. Cells marked `?` were not directly verifiable from the public surface and should be confirmed by the tool's author before being cited externally.
+Survey conducted May 2026 from each tool's then-current live build, GitHub repo, and README. Cells marked `?` were not directly verifiable from the public surface and should be confirmed by the tool's author before being cited externally.
+
+<details>
+<summary>Click to expand the comparison tables</summary>
 
 #### Identity & metadata
 
@@ -82,7 +108,7 @@ For a guided tour, click the **Help** button in the header.
 | Author | [@mkpoli](https://github.com/mkpoli) | [Dani Polani](https://github.com/dani-polani) / [tinygodsdev](https://github.com/tinygodsdev) | [Jounlai Cho](https://github.com/jounlai) / [Heuron Corp.](https://heuron.com/) |
 | First public release | Aug 2022 | Apr 2026 | Mar 2026 |
 | Repo created | 2022-08-23 | 2026-04-18 | 2026-03-12 |
-| License | MIT (pending [#71](https://github.com/mkpoli/word-order/pull/71)) | MIT | MIT (README only — no `LICENSE` file in repo) |
+| License | MIT | MIT | MIT (README only — no `LICENSE` file in repo) |
 | GitHub stars (May 2026) | 13 | 1 | 5 |
 | Tech stack | SvelteKit 2 · Svelte 4 · TS · Vite 5 · Vercel | SvelteKit · Vite 8 · Docker | Static HTML/JS · D3 · no build |
 | Build step required | ✅ Vite | ✅ Vite | ❌ static files |
@@ -118,14 +144,14 @@ For a guided tour, click the **Help** button in the header.
 | Language metadata (family / typology / IPA) | ❌ | ❌ | ✅ extensive |
 | Mobile responsive | ? | ? | ✅ |
 | Keyboard navigation | ? | ? | ✅ arrow keys, random |
-| Guided tour / Help | ✅ (Help button) | ❌ | ❌ |
+| Guided tour / Help | ❌ | ❌ | ❌ |
 
 #### Persistence & sharing
 
 | Feature | Word Order Illustrator | Bitext Align | LangMap |
 |---|---|---|---|
 | Autosave (localStorage) | ✅ | ? | n/a |
-| Multiple workspaces / tabs | ✅ (per-tab autosave) | ❌ | n/a |
+| Multiple workspaces / tabs | ❌ | ❌ | n/a |
 | URL share (state in hash) | ❌ | ✅ | ✅ |
 | Social share buttons | ❌ | ✅ | ✅ X / Facebook / LINE |
 | Export SVG | ✅ vector | ✅ vector | ✅ |
@@ -135,6 +161,8 @@ For a guided tour, click the **Help** button in the header.
 | Export JSON (project archive) | ✅ | ❌ | ❌ |
 | Export CSV | ❌ | ❌ | ✅ |
 | SEO (OG image, JSON-LD) | ✅ | ❌ | ❌ |
+
+</details>
 
 ## Developing
 
@@ -170,7 +198,12 @@ Missing keys fall back to the base locale (English), so translations can be incr
 
 ## Contributing
 
-Issues and pull requests welcome at <https://github.com/mkpoli/word-order/>.
+Issues and pull requests are welcome — <https://github.com/mkpoli/word-order/>.
+
+- **Bug reports**: include the live-demo URL with your `?` state if you can reproduce there, plus browser + OS. Screenshots help when the issue is visual.
+- **PRs**: please run `bun run lint`, `bun run check`, and `bun run test` before opening. If you touch user-visible strings, follow the [Adding a new UI language](#adding-a-new-ui-language) instructions and run `bun run paraglide:compile`.
+- **Commit style**: this repo uses [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `chore:`, etc.) — your PR's commits should follow suit.
+- **New examples** for the gallery are a great low-friction way to contribute: edit `src/lib/examples.ts`.
 
 ## Author
 


### PR DESCRIPTION
## Why

The README had drifted out of sync with shipped reality on several fronts: it claimed features that aren't on master (tabs, Help button), missed features that are (multi-tier annotations, per-side margin, PDF export, About dialog), and — after #47 just landed — said nothing about the BYO LLM translate-and-align flow. This PR brings it in line and tightens the shape.

> **Note**: this supersedes #76, which was a narrower subset of the same fixes against a slightly older master. Close #76 when this merges.

## What changed

### Tier-1 corrections (false / stale claims)

- "Multiple projects via tabs" → "localStorage autosave". Tabs were never shipped; the line lived only in an unmerged local commit.
- "Interlinear gloss row" → "Multi-tier annotations above and below" (from #65).
- Export list bumped from SVG/PNG/JSON → SVG/PNG/PDF/JSON (#28 has been merged for a while).
- UI language count 20+ → 30+ (currently 32 locales).
- Removed "click the Help button" — no Help button on master.
- Dropped "MIT pending #71" in the comparison table now that #71 is merged.
- Corrected table cells for tabs and Help that no longer hold.

### New content for BYO translate (#47)

Adds a dedicated **Translation assistance (BYO key)** subsection in Features:
- Provider choice (OpenAI / Anthropic / Gemini) with key stored only in localStorage
- Multi-target in one call with auto-glossed, auto-aligned rows
- Custom BCP-47 codes for conlangs and rare locales
- Settings dialog for provider + model picker

Plus a new step 2 in **How to use** describing the translate workflow.

### Structure & polish

- New **Who is it for?** section with four concrete personas (translator, learner, conlanger, linguist/teacher) — the tagline was the only positioning copy before.
- Features regrouped into four labelled subsections (Editor & rendering, Translation assistance, Persistence / examples / export, Localization & SEO) so the list scans at a glance.
- Comparison tables wrapped in a \`<details>\` block so they don't dominate the README; the prose intro still surfaces the key peers above the fold.
- Dropped the two leftover \`> **TODO**\` banners — they were scaffolding from the first draft, no longer needed now that the cells are filled in.
- **Contributing** expanded from one line to four practical bullets (bug-report format, PR checks before opening, conventional commits expectation, pointer to \`examples.ts\` for low-friction contributions).

## Out of scope (intentionally)

- No badges added (subjective; happy to do in a follow-up if you want shields.io stars / license / build).
- No screenshots or GIFs added (would need real captures).
- No TOC added — the README is long but the new section grouping should make navigation easy enough.
- No Tech-stack changes — Svelte 5 / Vite 8 upgrade is still pending in #64.

## Test plan

- [ ] Render on GitHub and confirm the \`<details>\` block expands correctly.
- [ ] Confirm each new Features bullet matches the live demo.
- [ ] Spot-check the comparison-table cells that changed (license, tabs, Help).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with enhanced feature descriptions including locale-aware tokenization, multi-tier annotations, ruby support, and per-token editing capabilities.
  * Refreshed "Who is it for?" section and expanded "How to use" instructions with translation and export guidance.
  * Reworked tool comparison section with updated feature tracking and contribution guidelines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mkpoli/word-order/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->