### PR TITLE
feat(export): pick raster scale (2× / 3× / 4× / 6×) for PNG and PDF

### DIFF
--- a/project.inlang/messages/en.json
+++ b/project.inlang/messages/en.json
@@ -68,6 +68,7 @@
 	"menu_svg": "Export SVG",
 	"menu_png": "Export PNG",
 	"menu_pdf": "Export PDF",
+	"menu_raster_scale": "Scale (PNG / PDF):",
 	"menu_scramble": "Scramble colors",
 	"menu_examples": "Examples",
 	"menu_about": "About",

--- a/project.inlang/messages/en.json
+++ b/project.inlang/messages/en.json
@@ -68,7 +68,7 @@
 	"menu_svg": "Export SVG",
 	"menu_png": "Export PNG",
 	"menu_pdf": "Export PDF",
-	"menu_raster_scale": "Scale (PNG / PDF):",
+	"menu_raster_scale": "Raster scale:",
 	"menu_scramble": "Scramble colors",
 	"menu_examples": "Examples",
 	"menu_about": "About",

--- a/src/i18n/i18n-svelte.ts
+++ b/src/i18n/i18n-svelte.ts
@@ -92,6 +92,7 @@ const createLL = () => ({
 		svg: m.menu_svg,
 		png: m.menu_png,
 		pdf: m.menu_pdf,
+		rasterScale: m.menu_raster_scale,
 		scramble: m.menu_scramble,
 		about: m.menu_about,
 		settings: m.menu_settings,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1455,6 +1455,7 @@
 
 	.export-scale-row label {
 		font-weight: 600;
+		white-space: nowrap;
 	}
 
 	.export-scale-row select {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -104,6 +104,11 @@
 	let examplesOpen = false;
 	let translatePopoverOpen = false;
 
+	type RasterScale = 2 | 3 | 4 | 6;
+	const RASTER_SCALES: RasterScale[] = [2, 3, 4, 6];
+	const RASTER_SCALE_STORAGE_KEY = 'word-order:raster-scale';
+	let rasterScale: RasterScale = 2;
+
 	type PendingTranslation = {
 		abort: AbortController;
 		rowIndices: number[];
@@ -136,9 +141,15 @@
 		// mount + tick would clobber the just-populated bindings and leave the
 		// connector SVG empty until the next user interaction.
 		word_spans = sentences.map(() => []);
+
+		const storedScale = Number(window.localStorage.getItem(RASTER_SCALE_STORAGE_KEY));
+		if (RASTER_SCALES.includes(storedScale as RasterScale)) rasterScale = storedScale as RasterScale;
+
 		mounted = true;
 		await tick();
 	});
+
+	$: if (mounted) window.localStorage.setItem(RASTER_SCALE_STORAGE_KEY, String(rasterScale));
 
 	// Autosave on any change to sentences or equivalency. Skip while a translation is pending
 	// so we don't persist the empty placeholder rows.
@@ -367,10 +378,7 @@
 		const controller = new AbortController();
 		pendingTranslation = { abort: controller, rowIndices, targets: [...targets] };
 
-		const timeoutId = setTimeout(
-			() => controller.abort(new Error(`Timed out after ${TRANSLATE_TIMEOUT_MS / 1000}s`)),
-			TRANSLATE_TIMEOUT_MS
-		);
+		const timeoutId = setTimeout(() => controller.abort(new Error(`Timed out after ${TRANSLATE_TIMEOUT_MS / 1000}s`)), TRANSLATE_TIMEOUT_MS);
 
 		void runTranslate(controller, rowIndices, targets, sourcesSnapshot, startIdx, timeoutId);
 	}
@@ -663,7 +671,7 @@
 
 	async function exportPng() {
 		try {
-			const png = await exportPngBlob();
+			const png = await exportPngBlob(rasterScale);
 			if (png) save(png, 'image/png', exportFilename('png'));
 		} catch (err) {
 			console.error('Export PNG failed:', err);
@@ -678,7 +686,7 @@
 			return;
 		}
 		try {
-			const scale = 2;
+			const scale = rasterScale;
 			const dataUrl = await domToImage.toPng(output, {
 				width: output.clientWidth * scale,
 				height: output.clientHeight * scale,
@@ -826,6 +834,14 @@
 				<iconify-icon icon="mdi:file-pdf-box" inline="true" />
 				PDF
 			</button>
+			<div class="export-scale-row">
+				<label for="raster-scale-select">{$LL.menu.rasterScale()}</label>
+				<select id="raster-scale-select" bind:value={rasterScale} disabled={mode === 'edit'}>
+					{#each RASTER_SCALES as s (s)}
+						<option value={s}>{s}×</option>
+					{/each}
+				</select>
+			</div>
 		</div>
 	</div>
 	<button class="about-button" title={$LL.menu.settings()} aria-label={$LL.menu.settings()} on:click={() => (settingsOpen = true)}>
@@ -865,7 +881,13 @@
 			<button type="button" class="translate-slot-action" title={$LL.translate.retry()} on:click={retryTranslate} aria-label={$LL.translate.retry()}>
 				<iconify-icon icon="mdi:refresh" inline="true" />
 			</button>
-			<button type="button" class="translate-slot-action" title={$LL.translate.dismissError()} on:click={dismissTranslateError} aria-label={$LL.translate.dismissError()}>
+			<button
+				type="button"
+				class="translate-slot-action"
+				title={$LL.translate.dismissError()}
+				on:click={dismissTranslateError}
+				aria-label={$LL.translate.dismissError()}
+			>
 				<iconify-icon icon="material-symbols:close-rounded" inline="true" />
 			</button>
 		</div>
@@ -933,12 +955,8 @@
 						const src = sentences[sentence];
 						wordsBeforeModify = getSentenceWords(src);
 						editingText = wordsBeforeModify.join('|');
-						annotationsAboveBeforeModify = Array.from({ length: src.lanesAbove }, (_, lane) =>
-							src.tokens.map((t) => t.annotationsAbove[lane] ?? '')
-						);
-						annotationsBelowBeforeModify = Array.from({ length: src.lanesBelow }, (_, lane) =>
-							src.tokens.map((t) => t.annotationsBelow[lane] ?? '')
-						);
+						annotationsAboveBeforeModify = Array.from({ length: src.lanesAbove }, (_, lane) => src.tokens.map((t) => t.annotationsAbove[lane] ?? ''));
+						annotationsBelowBeforeModify = Array.from({ length: src.lanesBelow }, (_, lane) => src.tokens.map((t) => t.annotationsBelow[lane] ?? ''));
 						editingAnnotationsAbove = annotationsAboveBeforeModify.map((lane) => [...lane]);
 						editingAnnotationsBelow = annotationsBelowBeforeModify.map((lane) => [...lane]);
 						editingShowGloss = src.showGloss;
@@ -1419,6 +1437,37 @@
 	}
 
 	.export-menu button:disabled {
+		opacity: 0.5;
+		cursor: default;
+	}
+
+	.export-scale-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.6em;
+		padding: 0.4em 0.85em 0.2em;
+		margin-top: 0.25em;
+		border-top: 1px solid #eee;
+		font-size: 0.85em;
+		color: #555;
+	}
+
+	.export-scale-row label {
+		font-weight: 600;
+	}
+
+	.export-scale-row select {
+		font: inherit;
+		font-weight: bold;
+		padding: 0.15em 0.35em;
+		border-radius: 0.25em;
+		border: 1px solid #ccc;
+		background: white;
+		color: #333;
+	}
+
+	.export-scale-row select:disabled {
 		opacity: 0.5;
 		cursor: default;
 	}


### PR DESCRIPTION
Closes #55.

## Summary

PNG and PDF export were both hardcoded at 2× scale, which is fine for typical viewing but blurry on 4K screens or when zoomed in for class slides. Adds a small picker to the bottom of the Export menu with the common scale options (2×, 3×, 4×, 6× — matching the range Bitext Align offers).

## Behavior

- The picked value applies to **both PNG and PDF** (both raster via \`dom-to-image\`).
- **SVG and JSON exports are unaffected** — vector / data formats don't scale.
- Choice **persists to localStorage** under \`word-order:raster-scale\` so it survives a reload.
- Defaults to **2×** to preserve existing behavior for anyone who never touches the picker.

## i18n

One new key \`menu_raster_scale\` added to \`en.json\`. Other locales fall back to English until someone translates the string.

## Verified

- \`bun run check\` — 0 errors (15 pre-existing warnings, none from my changes).
- \`bun run build\` — clean Vite build.
- \`prettier --check\` and \`eslint\` on the touched files — clean.

## Screenshots / manual test plan

- [ ] Open Export menu → confirm the new "Scale (PNG / PDF):" row appears at the bottom with options 2×/3×/4×/6×.
- [ ] Change scale to 4× → export PNG → confirm output is 2× larger in each dimension than the 2× export.
- [ ] Reload the page → confirm the picker remembers the last selection.
- [ ] Confirm SVG and JSON exports work identically regardless of scale.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable "Raster scale" selector for PNG/PDF exports (affects output quality and file size). Selection is restored from and saved to local storage; control is disabled in edit mode. Exports now use the chosen scale.
* **Localization**
  * English UI now includes a "Raster scale:" label for the export menu.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mkpoli/word-order/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->