### PR TITLE
chore(ci): add GitHub Actions workflow for check / lint / build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+jobs:
+  check:
+    name: check / lint / build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Generate i18n message modules
+        run: bun run paraglide:compile
+
+      - name: Type-check (svelte-check)
+        run: bun run check
+
+      - name: Lint (prettier + eslint)
+        run: bun run lint
+
+      - name: Build
+        run: bun run build

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,6 +7,13 @@ node_modules
 .env.*
 !.env.example
 /src/i18n/i18n-*.ts
+/src/lib/paraglide
+/project.inlang/.meta.json
+/project.inlang/README.md
+
+# Hand-formatted README — prettier reflows markdown tables to column-aligned form
+# which makes editing painful. Keep the loose single-line style.
+/README.md
 
 # Ignore files for PNPM, NPM and YARN
 pnpm-lock.yaml

--- a/src/lib/Output.svelte
+++ b/src/lib/Output.svelte
@@ -488,7 +488,12 @@
 		{/if}
 		{#if outputMargin.top > 0}<span class="dim-label">{outputMargin.top}px</span>{/if}
 	</div>
-	<div class="margin-band margin-band-bottom" class:active={marginDrag?.side === 'bottom'} style:height={`${outputMargin.bottom}px`} aria-hidden="true">
+	<div
+		class="margin-band margin-band-bottom"
+		class:active={marginDrag?.side === 'bottom'}
+		style:height={`${outputMargin.bottom}px`}
+		aria-hidden="true"
+	>
 		{#if outputMargin.bottom >= 14}
 			<svg class="dim-svg" width="20" height={outputMargin.bottom}>
 				<line x1="10" y1="0" x2="10" y2={outputMargin.bottom} class="dim-line" />
@@ -589,113 +594,113 @@
 		{#each sentences as sentence, i}
 			{@const { lang, tokens } = sentence}
 			{#if !pendingIndices.has(i)}
-			<div class="sentence" class:dragged={draggingIndex === i} class:modifying={modifying === i}>
-				<div class="dragger action" on:pointerdown={(e) => dragstart(i, e)} bind:this={draggers[i]}>
-					<iconify-icon icon="material-symbols:drag-indicator" width="1.2em" height="1.2em" />
-				</div>
-				<span class="tag" style:transform={getTransform(i, draggingOffset)}>{getLanguageName(lang, $locale)}</span>
-				<div class="sentence-body" class:with-gloss={sentenceShowsGloss(sentence)} style:transform={getTransform(i, draggingOffset)}>
-					<span class="words" {lang} dir={getLocaleDirection(lang)} style:text-align={alignment}>
-						{#each tokens as token, j}
-							{@const word = token.text}
-							{@const hasAboveLanes = sentence.lanesAbove > 0}
-							{@const hasBelowLanes = sentence.lanesBelow > 0}
-							<!-- svelte-ignore a11y-click-events-have-key-events -->
-							<span class="token" class:with-gloss={sentenceShowsGloss(sentence) && isContent(word)}>
-								{#if hasAboveLanes}
-									<span class="annotations-above" style:font-size={`${glossFontSize}px`}>
-										{#each Array(sentence.lanesAbove) as _, laneIndex}
-											<span class="annotation-line annotation-above">
-												{isContent(word) ? (token.annotationsAbove[laneIndex] ?? '') : ''}
-											</span>
-										{/each}
-									</span>
-								{/if}
-								<span
-									class="word"
-									class:whitespace={isWhitespace(word)}
-									class:content={isContent(word)}
-									class:editing={mode === 'edit'}
-									class:token-selected={i === modifying && selectedWordStart !== -1 && j >= selectedWordStart && j <= selectedWordEnd}
-									class:connected={connecting.some(([l, w]) => l == i && w == j)}
-									style:width={isWhitespace(word) ? `${Array.from(word).length * spaceWidth}px` : undefined}
-									style:color={colors[color_map[i][j]]}
-									on:click={() => {
-										if (i === modifying) {
-											selectEditingWord(i, j);
-											return;
-										}
-
-										if (!isContent(word)) return;
-
-										const entryIndex = color_map[i][j];
-
-										if (mode === 'view') {
-											mode = 'edit';
-
-											if (entryIndex !== -1) {
-												connected = [];
-												for (let [i, words] of equivalency[entryIndex].entries()) {
-													for (let word of words) {
-														connected.push([i, word]);
-													}
-												}
-
-												connecting = connected.map(([l, w]) => [l, w]);
-												connectedIndex = entryIndex;
+				<div class="sentence" class:dragged={draggingIndex === i} class:modifying={modifying === i}>
+					<div class="dragger action" on:pointerdown={(e) => dragstart(i, e)} bind:this={draggers[i]}>
+						<iconify-icon icon="material-symbols:drag-indicator" width="1.2em" height="1.2em" />
+					</div>
+					<span class="tag" style:transform={getTransform(i, draggingOffset)}>{getLanguageName(lang, $locale)}</span>
+					<div class="sentence-body" class:with-gloss={sentenceShowsGloss(sentence)} style:transform={getTransform(i, draggingOffset)}>
+						<span class="words" {lang} dir={getLocaleDirection(lang)} style:text-align={alignment}>
+							{#each tokens as token, j}
+								{@const word = token.text}
+								{@const hasAboveLanes = sentence.lanesAbove > 0}
+								{@const hasBelowLanes = sentence.lanesBelow > 0}
+								<!-- svelte-ignore a11y-click-events-have-key-events -->
+								<span class="token" class:with-gloss={sentenceShowsGloss(sentence) && isContent(word)}>
+									{#if hasAboveLanes}
+										<span class="annotations-above" style:font-size={`${glossFontSize}px`}>
+											{#each Array(sentence.lanesAbove) as _, laneIndex}
+												<span class="annotation-line annotation-above">
+													{isContent(word) ? (token.annotationsAbove[laneIndex] ?? '') : ''}
+												</span>
+											{/each}
+										</span>
+									{/if}
+									<span
+										class="word"
+										class:whitespace={isWhitespace(word)}
+										class:content={isContent(word)}
+										class:editing={mode === 'edit'}
+										class:token-selected={i === modifying && selectedWordStart !== -1 && j >= selectedWordStart && j <= selectedWordEnd}
+										class:connected={connecting.some(([l, w]) => l == i && w == j)}
+										style:width={isWhitespace(word) ? `${Array.from(word).length * spaceWidth}px` : undefined}
+										style:color={colors[color_map[i][j]]}
+										on:click={() => {
+											if (i === modifying) {
+												selectEditingWord(i, j);
 												return;
 											}
-										}
 
-										if (connecting.some(([l, w]) => l == i && w == j)) {
-											connecting = connecting.filter(([l, w]) => l != i || w != j);
-										} else {
-											connecting = [...connecting, [i, j]];
-										}
-									}}
-									bind:this={word_spans[i][j]}
-								>
-									<Word {word} />
-								</span>
-								{#if hasBelowLanes}
-									<span class="annotations-below" style:font-size={`${glossFontSize}px`}>
-										{#each Array(sentence.lanesBelow) as _, laneIndex}
-											<span class="annotation-line annotation-below">
-												{isContent(word) ? (token.annotationsBelow[laneIndex] ?? '') : ''}
-											</span>
-										{/each}
+											if (!isContent(word)) return;
+
+											const entryIndex = color_map[i][j];
+
+											if (mode === 'view') {
+												mode = 'edit';
+
+												if (entryIndex !== -1) {
+													connected = [];
+													for (let [i, words] of equivalency[entryIndex].entries()) {
+														for (let word of words) {
+															connected.push([i, word]);
+														}
+													}
+
+													connecting = connected.map(([l, w]) => [l, w]);
+													connectedIndex = entryIndex;
+													return;
+												}
+											}
+
+											if (connecting.some(([l, w]) => l == i && w == j)) {
+												connecting = connecting.filter(([l, w]) => l != i || w != j);
+											} else {
+												connecting = [...connecting, [i, j]];
+											}
+										}}
+										bind:this={word_spans[i][j]}
+									>
+										<Word {word} />
 									</span>
-								{/if}
-							</span>
-						{/each}
-					</span>
+									{#if hasBelowLanes}
+										<span class="annotations-below" style:font-size={`${glossFontSize}px`}>
+											{#each Array(sentence.lanesBelow) as _, laneIndex}
+												<span class="annotation-line annotation-below">
+													{isContent(word) ? (token.annotationsBelow[laneIndex] ?? '') : ''}
+												</span>
+											{/each}
+										</span>
+									{/if}
+								</span>
+							{/each}
+						</span>
+					</div>
+					<div class="modify action">
+						<!-- svelte-ignore a11y-click-events-have-key-events -->
+						<iconify-icon
+							icon="material-symbols:edit-rounded"
+							on:click={() => {
+								dispatch('modify', {
+									sentence: i
+								});
+							}}
+						/>
+					</div>
+					<div class="delete action">
+						<!-- svelte-ignore a11y-click-events-have-key-events -->
+						<iconify-icon
+							icon="ic:baseline-delete-forever"
+							width="1.2em"
+							height="1.2em"
+							on:click={() => {
+								if (!confirm($LL.confirm.deleteSentence())) return;
+								dispatch('delete', {
+									sentence: i
+								});
+							}}
+						/>
+					</div>
 				</div>
-				<div class="modify action">
-					<!-- svelte-ignore a11y-click-events-have-key-events -->
-					<iconify-icon
-						icon="material-symbols:edit-rounded"
-						on:click={() => {
-							dispatch('modify', {
-								sentence: i
-							});
-						}}
-					/>
-				</div>
-				<div class="delete action">
-					<!-- svelte-ignore a11y-click-events-have-key-events -->
-					<iconify-icon
-						icon="ic:baseline-delete-forever"
-						width="1.2em"
-						height="1.2em"
-						on:click={() => {
-							if (!confirm($LL.confirm.deleteSentence())) return;
-							dispatch('delete', {
-								sentence: i
-							});
-						}}
-					/>
-				</div>
-			</div>
 			{/if}
 		{/each}
 		{#if pendingIndices.size > 0}

--- a/src/lib/Parameters.svelte
+++ b/src/lib/Parameters.svelte
@@ -208,5 +208,4 @@
 		border: 1px solid var(--color-border);
 		border-radius: 0.2em;
 	}
-
 </style>

--- a/src/lib/SentenceInput.svelte
+++ b/src/lib/SentenceInput.svelte
@@ -190,7 +190,7 @@
 							{/each}
 							<span class="lane-corner" aria-hidden="true"></span>
 
-							{#each annotationsBelow as lane, laneIndex (`below-${laneIndex}`)}
+							{#each annotationsBelow as _lane, laneIndex (`below-${laneIndex}`)}
 								<span class="lane-label">{$LL.input.laneBelow({ n: laneIndex + 1 })}</span>
 								{#each glossableTokens as { tokenIndex } (tokenIndex)}
 									<input

--- a/src/lib/examples.ts
+++ b/src/lib/examples.ts
@@ -216,18 +216,8 @@ export const EXAMPLES: Example[] = [
 		id: 'romanization-above-below',
 		name: 'Romanization + gloss',
 		sentences: [
-			s(
-				'ja',
-				['私', 'は', '本', 'を', '読む', '。'],
-				['1SG', 'TOP', 'book', 'ACC', 'read', ''],
-				['watashi', 'wa', 'hon', 'o', 'yomu', '']
-			),
-			s(
-				'zh-HanS',
-				['我', '读', '书', '。'],
-				['1SG', 'read', 'book', ''],
-				['wǒ', 'dú', 'shū', '']
-			),
+			s('ja', ['私', 'は', '本', 'を', '読む', '。'], ['1SG', 'TOP', 'book', 'ACC', 'read', ''], ['watashi', 'wa', 'hon', 'o', 'yomu', '']),
+			s('zh-HanS', ['我', '读', '书', '。'], ['1SG', 'read', 'book', ''], ['wǒ', 'dú', 'shū', '']),
 			s('en', ['I', ' ', 'read', ' ', 'a', ' ', 'book', '.'], ['1SG', '', 'read', '', 'INDF', '', 'book', ''])
 		],
 		equivalency: [

--- a/src/lib/gloss-align.ts
+++ b/src/lib/gloss-align.ts
@@ -25,10 +25,7 @@ function normalize(s: string): string {
  * Keeps multi-character glosses with underscores intact ("to_me" stays "to_me").
  */
 function normalizeGlossKey(g: string): string {
-	return g
-		.toLowerCase()
-		.split(/[.\-]/)[0]
-		.trim();
+	return g.toLowerCase().split(/[.\-]/)[0].trim();
 }
 
 /**
@@ -48,11 +45,7 @@ function normalizeGlossKey(g: string): string {
  *
  * Manual user-made groups are preserved.
  */
-export function addGlossAlignments(
-	sentences: Sentence[],
-	existing: number[][][],
-	newSentenceIndices: number[]
-): number[][][] {
+export function addGlossAlignments(sentences: Sentence[], existing: number[][][], newSentenceIndices: number[]): number[][][] {
 	const newSet = new Set(newSentenceIndices);
 
 	// Bucket every glossed token across all sentences by its NORMALISED gloss key

--- a/src/lib/llm/providers/anthropic.ts
+++ b/src/lib/llm/providers/anthropic.ts
@@ -6,15 +6,7 @@ const TOOL_NAME = 'emit_translation';
 export const anthropic: LlmProvider = {
 	id: 'anthropic',
 	label: 'Anthropic',
-	models: [
-		'claude-opus-4-7',
-		'claude-sonnet-4-6',
-		'claude-haiku-4-5',
-		'claude-opus-4-6',
-		'claude-sonnet-4-5',
-		'claude-opus-4-5',
-		'claude-opus-4-1'
-	],
+	models: ['claude-opus-4-7', 'claude-sonnet-4-6', 'claude-haiku-4-5', 'claude-opus-4-6', 'claude-sonnet-4-5', 'claude-opus-4-5', 'claude-opus-4-1'],
 	defaultModel: 'claude-haiku-4-5',
 	keyHint: 'sk-ant-…',
 	async call(request, { apiKey, model, signal }) {

--- a/src/lib/llm/providers/gemini.ts
+++ b/src/lib/llm/providers/gemini.ts
@@ -21,14 +21,7 @@ const GEMINI_SCHEMA = toGeminiSchema(RESPONSE_JSON_SCHEMA);
 export const gemini: LlmProvider = {
 	id: 'gemini',
 	label: 'Google Gemini',
-	models: [
-		'gemini-3.5-flash',
-		'gemini-3.1-pro-preview',
-		'gemini-3.1-flash-lite',
-		'gemini-2.5-pro',
-		'gemini-2.5-flash',
-		'gemini-2.5-flash-lite'
-	],
+	models: ['gemini-3.5-flash', 'gemini-3.1-pro-preview', 'gemini-3.1-flash-lite', 'gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-2.5-flash-lite'],
 	defaultModel: 'gemini-2.5-flash',
 	keyHint: 'AIza…',
 	async call(request, { apiKey, model, signal }) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -67,9 +67,7 @@ export function getLaneValues(sentence: Sentence, position: AnnotationPosition, 
 export function setTokenAnnotation(token: SentenceToken, position: AnnotationPosition, lane: number, value: string): SentenceToken {
 	const annotations = position === 'above' ? [...token.annotationsAbove] : [...token.annotationsBelow];
 	annotations[lane] = value;
-	return position === 'above'
-		? { ...token, annotationsAbove: annotations }
-		: { ...token, annotationsBelow: annotations };
+	return position === 'above' ? { ...token, annotationsAbove: annotations } : { ...token, annotationsBelow: annotations };
 }
 
 /** Pad/truncate each token's annotation arrays to match `lanesAbove` and `lanesBelow`. */
@@ -119,10 +117,8 @@ export function normalizeSentence(sentence: SentenceData): Sentence {
 
 	if ('tokens' in sentence && Array.isArray(sentence.tokens)) {
 		const tokens = sentence.tokens.map(normalizeToken);
-		const lanesAbove =
-			(sentence as { lanesAbove?: number }).lanesAbove ?? tokens.reduce((max, t) => Math.max(max, t.annotationsAbove.length), 0);
-		const lanesBelow =
-			(sentence as { lanesBelow?: number }).lanesBelow ?? tokens.reduce((max, t) => Math.max(max, t.annotationsBelow.length), 0);
+		const lanesAbove = (sentence as { lanesAbove?: number }).lanesAbove ?? tokens.reduce((max, t) => Math.max(max, t.annotationsAbove.length), 0);
+		const lanesBelow = (sentence as { lanesBelow?: number }).lanesBelow ?? tokens.reduce((max, t) => Math.max(max, t.annotationsBelow.length), 0);
 		const showGloss = sentence.showGloss ?? tokens.some((t) => t.annotationsAbove.some(Boolean) || t.annotationsBelow.some(Boolean));
 		return normalizeLanes({ lang: sentence.lang, tokens, lanesAbove, lanesBelow, showGloss });
 	}


### PR DESCRIPTION
Closes #84.

## What

\`.github/workflows/ci.yml\` runs on every push to \`master\` and every PR:

1. \`bun install --frozen-lockfile\` — catches lockfile drift.
2. \`bun run paraglide:compile\` — generates i18n modules.
3. \`bun run check\` — paraglide compile + svelte-kit sync + svelte-check.
4. \`bun run lint\` — prettier + eslint.
5. \`bun run build\` — Vite + adapter-vercel.

Playwright not included yet — no real test suite exists. Can fold in alongside #51.

## Prerequisite fixes folded in

Pre-existing repo state would have failed CI immediately, so this PR also fixes:

- \`.prettierignore\` extended to skip generated / inlang-managed files:
  - \`src/lib/paraglide\` (generated by \`paraglide:compile\`)
  - \`project.inlang/.meta.json\`, \`project.inlang/README.md\` (inlang manages these)
  - \`README.md\` (prettier reflows markdown tables to column-aligned form, which makes editing painful — kept the loose single-line style)
- \`prettier --write\` applied to 8 source files that had drifted (\`Output.svelte\`, \`Parameters.svelte\`, \`SentenceInput.svelte\`, \`examples.ts\`, \`gloss-align.ts\`, two LLM provider files, \`types.ts\`). Whitespace-only diffs.
- One eslint error in \`SentenceInput.svelte\` (unused \`lane\` iterator) fixed by renaming to \`_lane\` — the project's no-unused-vars rule allows underscore-prefixed names.

## Verified

- \`bun run lint\` — clean
- \`bun run check\` — 0 errors (15 pre-existing warnings)
- \`bun run build\` — clean

## After merge

Worth following up with a branch-protection rule on \`master\` that requires the \`CI / check / lint / build\` check to pass before merging.