### PR TITLE
chore(ci): GitHub Actions with check / lint / build + Playwright smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+jobs:
+  static:
+    name: check / lint / build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Generate i18n message modules
+        run: bun run paraglide:compile
+
+      - name: Type-check (svelte-check)
+        run: bun run check
+
+      - name: Lint (prettier + eslint)
+        run: bun run lint
+
+      - name: Build
+        run: bun run build
+
+  smoke:
+    name: playwright smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Generate i18n message modules
+        run: bun run paraglide:compile
+
+      # Build is the same artifact production uses — preview server in playwright
+      # config serves it.
+      - name: Build
+        run: bun run build
+
+      - name: Install Playwright browsers
+        run: bunx playwright install --with-deps chromium
+
+      - name: Run Playwright smoke tests
+        run: bun run test
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ node_modules
 .env.*
 !.env.example
 .vercel
+/test-results
+/playwright-report

--- a/.prettierignore
+++ b/.prettierignore
@@ -13,3 +13,11 @@ pnpm-lock.yaml
 package-lock.json
 yarn.lock
 /src/lib/paraglide
+/project.inlang/.meta.json
+/project.inlang/README.md
+/test-results
+/playwright-report
+
+# Hand-formatted README — prettier reflows markdown tables to column-aligned form
+# which makes editing painful. Keep the loose single-line style.
+/README.md

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -869,7 +869,7 @@ ${svgString}
 				<iconify-icon icon="mdi:file-pdf-box" inline="true"></iconify-icon>
 				PDF
 			</button>
-			<button type="button" disabled={mode === 'edit'} on:click={exportHtml}>
+			<button type="button" disabled={mode === 'edit'} onclick={exportHtml}>
 				<iconify-icon icon="mdi:language-html5" inline="true" />
 				HTML
 			</button>

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Smoke tests that catch real regressions check/lint/build can't:
+ * - Hydration errors / broken event handlers (theme toggle, dialogs).
+ * - Wiring breaks in the export menu.
+ * - Theme system: data-theme attribute flips, output canvas stays light
+ *   in both themes (regression: the canvas was briefly being themed by
+ *   the page palette during the dark-mode work).
+ */
+import { expect, test } from '@playwright/test';
+
+test('page loads without console errors', async ({ page }) => {
+	const errors: string[] = [];
+	page.on('pageerror', (err) => errors.push(`pageerror: ${err.message}`));
+	page.on('console', (msg) => {
+		if (msg.type() === 'error') errors.push(`console.error: ${msg.text()}`);
+	});
+
+	await page.goto('/');
+	await page.waitForLoadState('networkidle');
+
+	expect(errors, errors.join('\n')).toEqual([]);
+});
+
+test('theme toggle cycles system → light → dark', async ({ page }) => {
+	await page.addInitScript(() => {
+		try {
+			localStorage.removeItem('word-order:theme');
+		} catch {
+			// localStorage may be unavailable in some browser contexts; non-fatal.
+		}
+	});
+	await page.goto('/');
+
+	const html = page.locator('html');
+	const toggle = page.locator('button.theme-toggle');
+
+	await expect(toggle).toBeVisible();
+	await expect(html).not.toHaveAttribute('data-theme', /.+/); // system → no attribute
+
+	await toggle.click(); // → light
+	await expect(html).toHaveAttribute('data-theme', 'light');
+
+	await toggle.click(); // → dark
+	await expect(html).toHaveAttribute('data-theme', 'dark');
+
+	await toggle.click(); // → system
+	await expect(html).not.toHaveAttribute('data-theme', /.+/);
+});
+
+test('output canvas stays light in both themes (export consistency)', async ({ page }) => {
+	await page.goto('/');
+
+	for (const theme of ['light', 'dark'] as const) {
+		await page.evaluate((t) => document.documentElement.setAttribute('data-theme', t), theme);
+		const canvasBg = await page.evaluate(() => {
+			const el = document.querySelector('output');
+			return el ? getComputedStyle(el).backgroundColor : null;
+		});
+		expect(canvasBg, `output canvas bg in ${theme} theme`).toBe('rgb(255, 255, 255)');
+	}
+});
+
+test('settings dialog opens and closes', async ({ page }) => {
+	await page.goto('/');
+
+	const trigger = page.locator('button.about-button[aria-label="Settings"]');
+	await trigger.click();
+	const dialog = page.locator('[role="dialog"][aria-labelledby="settings-title"]');
+	await expect(dialog).toBeVisible();
+
+	await page.keyboard.press('Escape');
+	await expect(dialog).not.toBeVisible();
+});
+
+test('export menu opens with the format buttons', async ({ page }) => {
+	await page.goto('/');
+
+	// Dropdown opens on hover *or* click; hover is the more reliable trigger
+	// here since click can race with the mouseleave handler.
+	await page.locator('.export-dropdown').hover();
+
+	const menu = page.locator('.export-menu');
+	await expect(menu).toBeVisible();
+	for (const fmt of ['JSON', 'SVG', 'PNG', 'PDF', 'HTML']) {
+		await expect(menu.getByRole('button', { name: fmt, exact: true })).toBeVisible();
+	}
+});


### PR DESCRIPTION
Closes #84. Supersedes #87.

Your feedback on the previous attempt: \`check / lint / build\` alone don't catch the visual / event-handler regressions we've actually been running into during the dark-mode work. This redesign adds a Playwright smoke job that exercises the real UI.

## Two jobs

**\`static\`** — \`install\` → \`paraglide:compile\` → \`check\` → \`lint\` → \`build\`. Catches type errors, formatting drift, eslint, build failures.

**\`smoke\`** — Playwright + chromium against the built preview server. Five tests:

1. **Page loads without console errors** — hydration / import regressions.
2. **Theme toggle cycles** system → light → dark and back. Would have caught wiring breaks during the recent Svelte 4→5 migration.
3. **Output canvas stays light in both themes.** Regression guard for the recent #56 fix where the page palette briefly bled into the canvas.
4. **Settings dialog opens and closes.** Catches dialog event regressions.
5. **Export menu opens with all five format buttons** (JSON / SVG / PNG / PDF / HTML).

On failure, the Playwright HTML report is uploaded as an artifact for inspection.

## ⚠️ Drive-by master fix folded in

\`src/routes/+page.svelte:872\` — \`on:click={exportHtml}\` → \`onclick={exportHtml}\`. The HTML export button from #88 merged *before* the Svelte 5 migration #64 and was left with the old syntax, which **currently breaks the build on master itself**. Caught by running \`bun run build\` on a fresh master checkout while validating this PR.

## Other housekeeping

- \`.prettierignore\`: skip inlang-managed files and \`README.md\` (prettier reflows its markdown tables badly).
- \`.gitignore\` + \`.prettierignore\`: skip Playwright's \`test-results/\` and \`playwright-report/\` output dirs.

## Verified

- \`bun run check\` — 0 errors (27 pre-existing warnings).
- \`bun run lint\` — clean.
- \`bun run build\` — clean.
- \`bun run test\` — 5/5 passing in 13.8s.

## After merge

Worth gating master with a branch-protection rule that requires both \`static\` and \`smoke\` checks to pass.