### PR TITLE
fix(output): redraw connector lines when glossFontSize changes

### DIFF
--- a/src/lib/Output.svelte
+++ b/src/lib/Output.svelte
@@ -438,7 +438,16 @@
 		if (mounted && equivalency && !loading) lines = drawLines(word_spans, equivalency, verticalGap, lineGap, straightLength, endpointCorrection);
 	});
 	run(() => {
-		if (!loading && alignment && fontFamily && fontStyle && fontSize !== undefined && spaceWidth !== undefined && $locale)
+		if (
+			!loading &&
+			alignment &&
+			fontFamily &&
+			fontStyle &&
+			fontSize !== undefined &&
+			glossFontSize !== undefined &&
+			spaceWidth !== undefined &&
+			$locale
+		)
 			tick().then(() => {
 				lines = drawLines(word_spans, equivalency, verticalGap, lineGap, straightLength, endpointCorrection);
 			});

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -869,7 +869,7 @@ ${svgString}
 				<iconify-icon icon="mdi:file-pdf-box" inline="true"></iconify-icon>
 				PDF
 			</button>
-			<button type="button" disabled={mode === 'edit'} on:click={exportHtml}>
+			<button type="button" disabled={mode === 'edit'} onclick={exportHtml}>
 				<iconify-icon icon="mdi:language-html5" inline="true" />
 				HTML
 			</button>


### PR DESCRIPTION
Reported regression: changing the gloss font size shifts the word rows vertically (because annotation tiers above/below grow/shrink), but the connector lines kept their old endpoints — so the curves disconnect from the words.

## Root cause

\`src/lib/Output.svelte:440\` has a reactive \`run\` that re-triggers \`drawLines\` when relevant typography changes:

\`\`\`js
run(() => {
  if (!loading && alignment && fontFamily && fontStyle && fontSize !== undefined && spaceWidth !== undefined && \$locale)
    tick().then(() => {
      lines = drawLines(...);
    });
});
\`\`\`

\`glossFontSize\` was missing from this dependency list. Adding it so the same redraw fires.

## Drive-by master fix

\`src/routes/+page.svelte:872\` was \`on:click={exportHtml}\` — the HTML export PR (#88) merged before the Svelte 5 migration (#64) and that migration didn't touch it. **Master's build is currently broken because of this.** Migrated to \`onclick={exportHtml}\` so this PR's CI can pass.

The same fix is in PR #89 (CI workflow). Whichever merges first, the other PR's identical fix becomes a no-op — git handles it cleanly.

## Verified

- \`bun run check\` — 0 errors.
- \`bun run build\` — clean.
- Manual: bumping Gloss Font Size in the Options panel now re-routes the connector curves to the new word positions.