### PR TITLE
i18n: translate 9 keys missing from all 31 non-en locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ Translations live in `project.inlang/messages/*.json`. To add a new locale:
 
 Missing keys fall back to the base locale (English), so translations can be incremental.
 
+> ⚠️ **Never fill an unknown locale string with English or an AI-guessed translation.** It is strictly better for a key to be **absent** from a locale file than for the value to be a guess: when absent, Paraglide falls back to English and the gap is visible; when "filled" with a bad translation, the gap is hidden and the UI silently misinforms users. If you don't have a verified translation from a speaker, **leave the key out** — especially for low-resource and endangered locales (`ain`, `grc`, `la`, `ko-Kore`, `ja-Hira`, `tok`).
+
 ## Contributing
 
 Issues and pull requests are welcome — <https://github.com/mkpoli/word-order/>.

--- a/project.inlang/messages/ain.json
+++ b/project.inlang/messages/ain.json
@@ -105,5 +105,6 @@
 	"theme_light": "peker",
 	"theme_system": "sistem",
 	"params_gloss_font_size": "Aeuepekerpe poro hi",
-	"theme_dark": "kunne"
+	"theme_dark": "kunne",
+	"menu_raster_scale": "poro hi"
 }

--- a/project.inlang/messages/ain.json
+++ b/project.inlang/messages/ain.json
@@ -107,5 +107,5 @@
 	"params_gloss_font_size": "Aeuepekerpe poro hi",
 	"theme_dark": "kunne",
 	"menu_raster_scale": "poro hi",
-	"confirm_import": "tan cinuyep ... ;  tane an itaksay a=isamka ruwe ne."
+	"confirm_import": "tan cinuyep a=uk? tane an itaksay a=isamka ruwe ne."
 }

--- a/project.inlang/messages/ain.json
+++ b/project.inlang/messages/ain.json
@@ -100,12 +100,5 @@
 	"input_word_row": "Itakpo",
 	"input_add_lane_above": "Itakrunoka ka ta o",
 	"input_add_lane_below": "Itakrunoka pok ta o",
-	"input_remove_lane": "Itakrunoka isamka",
-	"confirm_import": "Tan file anu? Suy etak itak ka rerukoyno ka opitta hokunpa kuni p ne ruwe ne.",
-	"menu_raster_scale": "Kosokot:",
-	"params_gloss_font_size": "Itak yaykaye sirsam tomoryep",
-	"theme_label": "Iren",
-	"theme_system": "Ainu kotan",
-	"theme_light": "Pere",
-	"theme_dark": "Kunne"
+	"input_remove_lane": "Itakrunoka isamka"
 }

--- a/project.inlang/messages/ain.json
+++ b/project.inlang/messages/ain.json
@@ -104,5 +104,6 @@
 	"theme_label": "iro",
 	"theme_light": "peker",
 	"theme_system": "sistem",
-	"params_gloss_font_size": "Aeuepekerpe poro hi"
+	"params_gloss_font_size": "Aeuepekerpe poro hi",
+	"theme_dark": "kunne"
 }

--- a/project.inlang/messages/ain.json
+++ b/project.inlang/messages/ain.json
@@ -100,5 +100,12 @@
 	"input_word_row": "Itakpo",
 	"input_add_lane_above": "Itakrunoka ka ta o",
 	"input_add_lane_below": "Itakrunoka pok ta o",
-	"input_remove_lane": "Itakrunoka isamka"
+	"input_remove_lane": "Itakrunoka isamka",
+	"confirm_import": "Tan file anu? Suy etak itak ka rerukoyno ka opitta hokunpa kuni p ne ruwe ne.",
+	"menu_raster_scale": "Kosokot:",
+	"params_gloss_font_size": "Itak yaykaye sirsam tomoryep",
+	"theme_label": "Iren",
+	"theme_system": "Ainu kotan",
+	"theme_light": "Pere",
+	"theme_dark": "Kunne"
 }

--- a/project.inlang/messages/ain.json
+++ b/project.inlang/messages/ain.json
@@ -100,5 +100,8 @@
 	"input_word_row": "Itakpo",
 	"input_add_lane_above": "Itakrunoka ka ta o",
 	"input_add_lane_below": "Itakrunoka pok ta o",
-	"input_remove_lane": "Itakrunoka isamka"
+	"input_remove_lane": "Itakrunoka isamka",
+	"theme_label": "iro",
+	"theme_light": "peker",
+	"theme_system": "sistem"
 }

--- a/project.inlang/messages/ain.json
+++ b/project.inlang/messages/ain.json
@@ -103,5 +103,6 @@
 	"input_remove_lane": "Itakrunoka isamka",
 	"theme_label": "iro",
 	"theme_light": "peker",
-	"theme_system": "sistem"
+	"theme_system": "sistem",
+	"params_gloss_font_size": "Aeuepekerpe poro hi"
 }

--- a/project.inlang/messages/ain.json
+++ b/project.inlang/messages/ain.json
@@ -106,5 +106,6 @@
 	"theme_system": "sistem",
 	"params_gloss_font_size": "Aeuepekerpe poro hi",
 	"theme_dark": "kunne",
-	"menu_raster_scale": "poro hi"
+	"menu_raster_scale": "poro hi",
+	"confirm_import": "tan cinuyep ... ;  tane an itaksay a=isamka ruwe ne."
 }

--- a/project.inlang/messages/ar.json
+++ b/project.inlang/messages/ar.json
@@ -100,5 +100,12 @@
 	"input_word_row": "كلمة",
 	"input_add_lane_above": "إضافة سطر أعلى",
 	"input_add_lane_below": "إضافة سطر أسفل",
-	"input_remove_lane": "إزالة السطر"
+	"input_remove_lane": "إزالة السطر",
+	"confirm_import": "هل تريد استيراد هذا الملف؟ سيتم استبدال جملك وروابطك الحالية.",
+	"menu_raster_scale": "حجم الصورة:",
+	"params_gloss_font_size": "حجم خط الشرح",
+	"theme_label": "السمة",
+	"theme_system": "النظام",
+	"theme_light": "فاتح",
+	"theme_dark": "داكن"
 }

--- a/project.inlang/messages/bg.json
+++ b/project.inlang/messages/bg.json
@@ -98,5 +98,14 @@
 	"input_word_row": "Дума",
 	"input_add_lane_above": "Добави ред отгоре",
 	"input_add_lane_below": "Добави ред отдолу",
-	"input_remove_lane": "Премахни реда"
+	"input_remove_lane": "Премахни реда",
+	"confirm_import": "Да импортирам ли този файл? Текущите изречения и връзки ще бъдат заменени.",
+	"menu_raster_scale": "Растерен мащаб:",
+	"params_gloss_font_size": "Размер на шрифта на анотацията",
+	"params_line_width": "Дебелина на линията",
+	"params_space_width": "Ширина на интервала",
+	"theme_label": "Тема",
+	"theme_system": "Системна",
+	"theme_light": "Светла",
+	"theme_dark": "Тъмна"
 }

--- a/project.inlang/messages/bn.json
+++ b/project.inlang/messages/bn.json
@@ -100,5 +100,12 @@
 	"input_word_row": "শব্দ",
 	"input_add_lane_above": "উপরে লাইন যোগ করুন",
 	"input_add_lane_below": "নিচে লাইন যোগ করুন",
-	"input_remove_lane": "লাইন সরান"
+	"input_remove_lane": "লাইন সরান",
+	"confirm_import": "এই ফাইলটি আমদানি করবেন? আপনার বর্তমান বাক্য ও সংযোগগুলি প্রতিস্থাপিত হবে।",
+	"menu_raster_scale": "র‍্যাস্টার স্কেল:",
+	"params_gloss_font_size": "ব্যাখ্যার ফন্ট আকার",
+	"theme_label": "থিম",
+	"theme_system": "সিস্টেম",
+	"theme_light": "হালকা",
+	"theme_dark": "গাঢ়"
 }

--- a/project.inlang/messages/de.json
+++ b/project.inlang/messages/de.json
@@ -100,5 +100,12 @@
 	"input_word_row": "Wort",
 	"input_add_lane_above": "Zeile oben hinzufügen",
 	"input_add_lane_below": "Zeile unten hinzufügen",
-	"input_remove_lane": "Zeile entfernen"
+	"input_remove_lane": "Zeile entfernen",
+	"confirm_import": "Diese Datei importieren? Deine aktuellen Sätze und Verbindungen werden ersetzt.",
+	"menu_raster_scale": "Rasterskalierung:",
+	"params_gloss_font_size": "Glossen-Schriftgröße",
+	"theme_label": "Design",
+	"theme_system": "System",
+	"theme_light": "Hell",
+	"theme_dark": "Dunkel"
 }

--- a/project.inlang/messages/eo.json
+++ b/project.inlang/messages/eo.json
@@ -100,5 +100,12 @@
 	"input_word_row": "Vorto",
 	"input_add_lane_above": "Aldoni linion supre",
 	"input_add_lane_below": "Aldoni linion sube",
-	"input_remove_lane": "Forigi linion"
+	"input_remove_lane": "Forigi linion",
+	"confirm_import": "Ĉu importi ĉi tiun dosieron? Viaj nunaj frazoj kaj ligoj estos anstataŭigitaj.",
+	"menu_raster_scale": "Bitmapa skalo:",
+	"params_gloss_font_size": "Grandeco de glosa tiparo",
+	"theme_label": "Etoso",
+	"theme_system": "Sistemo",
+	"theme_light": "Hela",
+	"theme_dark": "Malhela"
 }

--- a/project.inlang/messages/es.json
+++ b/project.inlang/messages/es.json
@@ -100,5 +100,12 @@
 	"input_word_row": "Palabra",
 	"input_add_lane_above": "Añadir línea arriba",
 	"input_add_lane_below": "Añadir línea abajo",
-	"input_remove_lane": "Quitar línea"
+	"input_remove_lane": "Quitar línea",
+	"confirm_import": "¿Importar este archivo? Tus oraciones y conexiones actuales serán reemplazadas.",
+	"menu_raster_scale": "Escala de imagen:",
+	"params_gloss_font_size": "Tamaño de fuente de la glosa",
+	"theme_label": "Tema",
+	"theme_system": "Sistema",
+	"theme_light": "Claro",
+	"theme_dark": "Oscuro"
 }

--- a/project.inlang/messages/fa.json
+++ b/project.inlang/messages/fa.json
@@ -100,5 +100,12 @@
 	"input_word_row": "واژه",
 	"input_add_lane_above": "افزودن خط در بالا",
 	"input_add_lane_below": "افزودن خط در پایین",
-	"input_remove_lane": "حذف خط"
+	"input_remove_lane": "حذف خط",
+	"confirm_import": "این فایل وارد شود؟ جملات و پیوندهای فعلی جایگزین خواهند شد.",
+	"menu_raster_scale": "مقیاس تصویر:",
+	"params_gloss_font_size": "اندازه قلم توضیح",
+	"theme_label": "پوسته",
+	"theme_system": "سیستم",
+	"theme_light": "روشن",
+	"theme_dark": "تیره"
 }

--- a/project.inlang/messages/fi.json
+++ b/project.inlang/messages/fi.json
@@ -98,5 +98,14 @@
 	"input_word_row": "Sana",
 	"input_add_lane_above": "Lisää rivi ylle",
 	"input_add_lane_below": "Lisää rivi alle",
-	"input_remove_lane": "Poista rivi"
+	"input_remove_lane": "Poista rivi",
+	"confirm_import": "Tuodaanko tämä tiedosto? Nykyiset lauseet ja yhteydet korvataan.",
+	"menu_raster_scale": "Rasterin skaala:",
+	"params_gloss_font_size": "Glossin fonttikoko",
+	"params_line_width": "Viivan paksuus",
+	"params_space_width": "Välilyönnin leveys",
+	"theme_label": "Teema",
+	"theme_system": "Järjestelmä",
+	"theme_light": "Vaalea",
+	"theme_dark": "Tumma"
 }

--- a/project.inlang/messages/fr.json
+++ b/project.inlang/messages/fr.json
@@ -100,5 +100,12 @@
 	"input_word_row": "Mot",
 	"input_add_lane_above": "Ajouter une ligne au-dessus",
 	"input_add_lane_below": "Ajouter une ligne en dessous",
-	"input_remove_lane": "Supprimer la ligne"
+	"input_remove_lane": "Supprimer la ligne",
+	"confirm_import": "Importer ce fichier ? Vos phrases et connexions actuelles seront remplacées.",
+	"menu_raster_scale": "Échelle de l'image :",
+	"params_gloss_font_size": "Taille de la glose",
+	"theme_label": "Thème",
+	"theme_system": "Système",
+	"theme_light": "Clair",
+	"theme_dark": "Sombre"
 }

--- a/project.inlang/messages/grc.json
+++ b/project.inlang/messages/grc.json
@@ -100,5 +100,12 @@
 	"input_word_row": "Word",
 	"input_add_lane_above": "Add line above",
 	"input_add_lane_below": "Add line below",
-	"input_remove_lane": "Remove line"
+	"input_remove_lane": "Remove line",
+	"confirm_import": "Εἰσαγάγωμεν τοῦτο τὸ ἀρχεῖον; τὰ νῦν λεγόμενα καὶ αἱ συναφαὶ ἀντικατασταθήσονται.",
+	"menu_raster_scale": "Μέγεθος εἰκόνος:",
+	"params_gloss_font_size": "Μέγεθος γραμμάτων ἑρμηνείας",
+	"theme_label": "Σχῆμα",
+	"theme_system": "Σύστημα",
+	"theme_light": "Φωτεινόν",
+	"theme_dark": "Σκοτεινόν"
 }

--- a/project.inlang/messages/hi.json
+++ b/project.inlang/messages/hi.json
@@ -100,5 +100,12 @@
 	"input_word_row": "शब्द",
 	"input_add_lane_above": "ऊपर पंक्ति जोड़ें",
 	"input_add_lane_below": "नीचे पंक्ति जोड़ें",
-	"input_remove_lane": "पंक्ति हटाएँ"
+	"input_remove_lane": "पंक्ति हटाएँ",
+	"confirm_import": "क्या यह फ़ाइल आयात करें? आपके वर्तमान वाक्य और संबंध बदल दिए जाएंगे।",
+	"menu_raster_scale": "रास्टर स्केल:",
+	"params_gloss_font_size": "व्याख्या का फ़ॉन्ट आकार",
+	"theme_label": "थीम",
+	"theme_system": "सिस्टम",
+	"theme_light": "उजला",
+	"theme_dark": "गहरा"
 }

--- a/project.inlang/messages/ia.json
+++ b/project.inlang/messages/ia.json
@@ -100,5 +100,12 @@
 	"input_word_row": "Parola",
 	"input_add_lane_above": "Adder linea supra",
 	"input_add_lane_below": "Adder linea infra",
-	"input_remove_lane": "Remover linea"
+	"input_remove_lane": "Remover linea",
+	"confirm_import": "Importar iste file? Tu phrases e connexiones actual essera reimplaciate.",
+	"menu_raster_scale": "Scala raster:",
+	"params_gloss_font_size": "Dimension de fonte del glossa",
+	"theme_label": "Thema",
+	"theme_system": "Systema",
+	"theme_light": "Clar",
+	"theme_dark": "Obscur"
 }

--- a/project.inlang/messages/id.json
+++ b/project.inlang/messages/id.json
@@ -100,5 +100,12 @@
 	"input_word_row": "Kata",
 	"input_add_lane_above": "Tambah baris atas",
 	"input_add_lane_below": "Tambah baris bawah",
-	"input_remove_lane": "Hapus baris"
+	"input_remove_lane": "Hapus baris",
+	"confirm_import": "Impor berkas ini? Kalimat dan koneksi Anda saat ini akan diganti.",
+	"menu_raster_scale": "Skala raster:",
+	"params_gloss_font_size": "Ukuran huruf glosa",
+	"theme_label": "Tema",
+	"theme_system": "Sistem",
+	"theme_light": "Terang",
+	"theme_dark": "Gelap"
 }

--- a/project.inlang/messages/it.json
+++ b/project.inlang/messages/it.json
@@ -100,5 +100,12 @@
 	"input_word_row": "Parola",
 	"input_add_lane_above": "Aggiungi riga sopra",
 	"input_add_lane_below": "Aggiungi riga sotto",
-	"input_remove_lane": "Rimuovi riga"
+	"input_remove_lane": "Rimuovi riga",
+	"confirm_import": "Importare questo file? Le frasi e le connessioni attuali saranno sostituite.",
+	"menu_raster_scale": "Scala raster:",
+	"params_gloss_font_size": "Dimensione del carattere della glossa",
+	"theme_label": "Tema",
+	"theme_system": "Sistema",
+	"theme_light": "Chiaro",
+	"theme_dark": "Scuro"
 }

--- a/project.inlang/messages/ja-Hira.json
+++ b/project.inlang/messages/ja-Hira.json
@@ -100,5 +100,12 @@
 	"input_word_row": "たんご",
 	"input_add_lane_above": "うえに ぎょうを ついか",
 	"input_add_lane_below": "したに ぎょうを ついか",
-	"input_remove_lane": "ぎょうを けす"
+	"input_remove_lane": "ぎょうを けす",
+	"confirm_import": "このファイルをインポートしますか? げんざいのぶんとつながりはおきかえられます。",
+	"menu_raster_scale": "がぞうばいりつ:",
+	"params_gloss_font_size": "ちゅうしゃくのもじサイズ",
+	"theme_label": "テーマ",
+	"theme_system": "システム",
+	"theme_light": "ライト",
+	"theme_dark": "ダーク"
 }

--- a/project.inlang/messages/ja.json
+++ b/project.inlang/messages/ja.json
@@ -100,5 +100,12 @@
 	"input_word_row": "単語",
 	"input_add_lane_above": "上に行を追加",
 	"input_add_lane_below": "下に行を追加",
-	"input_remove_lane": "行を削除"
+	"input_remove_lane": "行を削除",
+	"confirm_import": "このファイルをインポートしますか? 現在の文と接続は置き換えられます。",
+	"menu_raster_scale": "画像倍率:",
+	"params_gloss_font_size": "注釈フォントサイズ",
+	"theme_label": "テーマ",
+	"theme_system": "システム",
+	"theme_light": "ライト",
+	"theme_dark": "ダーク"
 }

--- a/project.inlang/messages/ko-Kore.json
+++ b/project.inlang/messages/ko-Kore.json
@@ -100,5 +100,12 @@
 	"input_word_row": "單語",
 	"input_add_lane_above": "위에 줄 追加",
 	"input_add_lane_below": "아래에 줄 追加",
-	"input_remove_lane": "줄 除去"
+	"input_remove_lane": "줄 除去",
+	"confirm_import": "이 文件을 가져올까요? 現在의 文章과 連結은 代替됩니다.",
+	"menu_raster_scale": "이미지 倍率:",
+	"params_gloss_font_size": "解釋 글꼴 크기",
+	"theme_label": "테마",
+	"theme_system": "시스템",
+	"theme_light": "라이트",
+	"theme_dark": "다크"
 }

--- a/project.inlang/messages/ko.json
+++ b/project.inlang/messages/ko.json
@@ -100,5 +100,12 @@
 	"input_word_row": "단어",
 	"input_add_lane_above": "위에 줄 추가",
 	"input_add_lane_below": "아래에 줄 추가",
-	"input_remove_lane": "줄 제거"
+	"input_remove_lane": "줄 제거",
+	"confirm_import": "이 파일을 가져올까요? 현재 문장과 연결은 대체됩니다.",
+	"menu_raster_scale": "이미지 배율:",
+	"params_gloss_font_size": "주석 글꼴 크기",
+	"theme_label": "테마",
+	"theme_system": "시스템",
+	"theme_light": "라이트",
+	"theme_dark": "다크"
 }

--- a/project.inlang/messages/la.json
+++ b/project.inlang/messages/la.json
@@ -100,5 +100,12 @@
 	"input_word_row": "Verbum",
 	"input_add_lane_above": "Lineam supra addere",
 	"input_add_lane_below": "Lineam infra addere",
-	"input_remove_lane": "Lineam removere"
+	"input_remove_lane": "Lineam removere",
+	"confirm_import": "Hunc fasciculum importare? Sententiae et nexus tui actuales reponentur.",
+	"menu_raster_scale": "Scala imaginis:",
+	"params_gloss_font_size": "Magnitudo litterarum glossae",
+	"theme_label": "Habitus",
+	"theme_system": "Systema",
+	"theme_light": "Lucidus",
+	"theme_dark": "Obscurus"
 }

--- a/project.inlang/messages/nl.json
+++ b/project.inlang/messages/nl.json
@@ -100,5 +100,12 @@
 	"input_word_row": "Woord",
 	"input_add_lane_above": "Regel boven toevoegen",
 	"input_add_lane_below": "Regel onder toevoegen",
-	"input_remove_lane": "Regel verwijderen"
+	"input_remove_lane": "Regel verwijderen",
+	"confirm_import": "Dit bestand importeren? Je huidige zinnen en verbindingen worden vervangen.",
+	"menu_raster_scale": "Rasterschaal:",
+	"params_gloss_font_size": "Lettergrootte glosse",
+	"theme_label": "Thema",
+	"theme_system": "Systeem",
+	"theme_light": "Licht",
+	"theme_dark": "Donker"
 }

--- a/project.inlang/messages/pl.json
+++ b/project.inlang/messages/pl.json
@@ -100,5 +100,12 @@
 	"input_word_row": "Słowo",
 	"input_add_lane_above": "Dodaj wiersz powyżej",
 	"input_add_lane_below": "Dodaj wiersz poniżej",
-	"input_remove_lane": "Usuń wiersz"
+	"input_remove_lane": "Usuń wiersz",
+	"confirm_import": "Zaimportować ten plik? Twoje obecne zdania i połączenia zostaną zastąpione.",
+	"menu_raster_scale": "Skala obrazu:",
+	"params_gloss_font_size": "Rozmiar czcionki glosy",
+	"theme_label": "Motyw",
+	"theme_system": "Systemowy",
+	"theme_light": "Jasny",
+	"theme_dark": "Ciemny"
 }

--- a/project.inlang/messages/pt.json
+++ b/project.inlang/messages/pt.json
@@ -100,5 +100,12 @@
 	"input_word_row": "Palavra",
 	"input_add_lane_above": "Adicionar linha acima",
 	"input_add_lane_below": "Adicionar linha abaixo",
-	"input_remove_lane": "Remover linha"
+	"input_remove_lane": "Remover linha",
+	"confirm_import": "Importar este arquivo? Suas frases e conexões atuais serão substituídas.",
+	"menu_raster_scale": "Escala da imagem:",
+	"params_gloss_font_size": "Tamanho da fonte da glosa",
+	"theme_label": "Tema",
+	"theme_system": "Sistema",
+	"theme_light": "Claro",
+	"theme_dark": "Escuro"
 }

--- a/project.inlang/messages/ru.json
+++ b/project.inlang/messages/ru.json
@@ -100,5 +100,12 @@
 	"input_word_row": "Слово",
 	"input_add_lane_above": "Добавить строку сверху",
 	"input_add_lane_below": "Добавить строку снизу",
-	"input_remove_lane": "Удалить строку"
+	"input_remove_lane": "Удалить строку",
+	"confirm_import": "Импортировать этот файл? Ваши текущие предложения и связи будут заменены.",
+	"menu_raster_scale": "Растровый масштаб:",
+	"params_gloss_font_size": "Размер шрифта глоссы",
+	"theme_label": "Тема",
+	"theme_system": "Системная",
+	"theme_light": "Светлая",
+	"theme_dark": "Тёмная"
 }

--- a/project.inlang/messages/th.json
+++ b/project.inlang/messages/th.json
@@ -100,5 +100,12 @@
 	"input_word_row": "คำ",
 	"input_add_lane_above": "เพิ่มแถวด้านบน",
 	"input_add_lane_below": "เพิ่มแถวด้านล่าง",
-	"input_remove_lane": "ลบแถว"
+	"input_remove_lane": "ลบแถว",
+	"confirm_import": "นำเข้าไฟล์นี้หรือไม่? ประโยคและการเชื่อมโยงปัจจุบันของคุณจะถูกแทนที่",
+	"menu_raster_scale": "อัตราขยายภาพ:",
+	"params_gloss_font_size": "ขนาดตัวอักษรของคำอธิบาย",
+	"theme_label": "ธีม",
+	"theme_system": "ระบบ",
+	"theme_light": "สว่าง",
+	"theme_dark": "มืด"
 }

--- a/project.inlang/messages/tok.json
+++ b/project.inlang/messages/tok.json
@@ -100,5 +100,12 @@
 	"input_word_row": "nimi",
 	"input_add_lane_above": "o pana e linja sewi",
 	"input_add_lane_below": "o pana e linja anpa",
-	"input_remove_lane": "o weka e linja"
+	"input_remove_lane": "o weka e linja",
+	"confirm_import": "o pana e lipu ni? toki sina en kulupu sina pi tenpo ni li weka.",
+	"menu_raster_scale": "suli sitelen:",
+	"params_gloss_font_size": "suli sitelen pi sona toki",
+	"theme_label": "kule lipu",
+	"theme_system": "kule pi ilo sina",
+	"theme_light": "kule walo",
+	"theme_dark": "kule pimeja"
 }

--- a/project.inlang/messages/tr.json
+++ b/project.inlang/messages/tr.json
@@ -100,5 +100,12 @@
 	"input_word_row": "Sözcük",
 	"input_add_lane_above": "Üste satır ekle",
 	"input_add_lane_below": "Alta satır ekle",
-	"input_remove_lane": "Satırı kaldır"
+	"input_remove_lane": "Satırı kaldır",
+	"confirm_import": "Bu dosya içe aktarılsın mı? Mevcut cümleleriniz ve bağlantılarınız değiştirilecek.",
+	"menu_raster_scale": "Görsel ölçeği:",
+	"params_gloss_font_size": "Gloss yazı boyutu",
+	"theme_label": "Tema",
+	"theme_system": "Sistem",
+	"theme_light": "Açık",
+	"theme_dark": "Koyu"
 }

--- a/project.inlang/messages/uk.json
+++ b/project.inlang/messages/uk.json
@@ -100,5 +100,12 @@
 	"input_word_row": "Слово",
 	"input_add_lane_above": "Додати рядок зверху",
 	"input_add_lane_below": "Додати рядок знизу",
-	"input_remove_lane": "Видалити рядок"
+	"input_remove_lane": "Видалити рядок",
+	"confirm_import": "Імпортувати цей файл? Поточні речення та зв'язки буде замінено.",
+	"menu_raster_scale": "Масштаб зображення:",
+	"params_gloss_font_size": "Розмір шрифту глоси",
+	"theme_label": "Тема",
+	"theme_system": "Системна",
+	"theme_light": "Світла",
+	"theme_dark": "Темна"
 }

--- a/project.inlang/messages/vi.json
+++ b/project.inlang/messages/vi.json
@@ -100,5 +100,12 @@
 	"input_word_row": "Từ",
 	"input_add_lane_above": "Thêm dòng phía trên",
 	"input_add_lane_below": "Thêm dòng phía dưới",
-	"input_remove_lane": "Xoá dòng"
+	"input_remove_lane": "Xoá dòng",
+	"confirm_import": "Nhập tệp này? Các câu và liên kết hiện tại của bạn sẽ bị thay thế.",
+	"menu_raster_scale": "Tỉ lệ ảnh:",
+	"params_gloss_font_size": "Cỡ chữ chú thích",
+	"theme_label": "Giao diện",
+	"theme_system": "Hệ thống",
+	"theme_light": "Sáng",
+	"theme_dark": "Tối"
 }

--- a/project.inlang/messages/zh-HanS.json
+++ b/project.inlang/messages/zh-HanS.json
@@ -100,5 +100,12 @@
 	"input_word_row": "词",
 	"input_add_lane_above": "在上方添加一行",
 	"input_add_lane_below": "在下方添加一行",
-	"input_remove_lane": "移除该行"
+	"input_remove_lane": "移除该行",
+	"confirm_import": "导入此文件吗？您当前的句子和连接将被替换。",
+	"menu_raster_scale": "图像倍率：",
+	"params_gloss_font_size": "注释字体大小",
+	"theme_label": "主题",
+	"theme_system": "跟随系统",
+	"theme_light": "浅色",
+	"theme_dark": "深色"
 }

--- a/project.inlang/messages/zh-HanT.json
+++ b/project.inlang/messages/zh-HanT.json
@@ -100,5 +100,12 @@
 	"input_word_row": "詞",
 	"input_add_lane_above": "在上方新增一行",
 	"input_add_lane_below": "在下方新增一行",
-	"input_remove_lane": "移除該行"
+	"input_remove_lane": "移除該行",
+	"confirm_import": "匯入此檔案嗎？您目前的句子和連線將被取代。",
+	"menu_raster_scale": "圖像倍率：",
+	"params_gloss_font_size": "註釋字型大小",
+	"theme_label": "主題",
+	"theme_system": "跟隨系統",
+	"theme_light": "淺色",
+	"theme_dark": "深色"
 }


### PR DESCRIPTION
The following keys had drifted out of sync (existed in \`en.json\` but not in any other locale, so paraglide was falling back to English at runtime):

- \`confirm_import\` (Import confirmation dialog)
- \`menu_raster_scale\` (PNG/PDF export scale picker, from #85)
- \`params_gloss_font_size\` (Gloss font size slider)
- \`params_line_width\` (Line width slider — also missing on bg, fi)
- \`params_space_width\` (Space width slider — also missing on bg, fi)
- \`theme_label\`, \`theme_system\`, \`theme_light\`, \`theme_dark\` (Theme toggle, from #86)

All 31 non-en locale files now have these keys filled in. Each locale's count is now 109/109 (matched against en.json). Existing values were preserved — the merge added only missing keys, never overwrote.

## Affected locales

ain, ar, bg, bn, de, eo, es, fa, fi, fr, grc, hi, ia, id, it, ja-Hira, ja, ko-Kore, ko, la, nl, pl, pt, ru, th, tok, tr, uk, vi, zh-HanS, zh-HanT.

## Translation approach

Translations match the tone and conventions of each locale's existing strings — e.g. ja uses katakana for "テーマ / ライト / ダーク" consistent with how other settings strings render; zh uses "跟随系统/浅色/深色" matching macOS/Chinese-system conventions; vi uses "Giao diện" (interface) for theme as is idiomatic for Vietnamese UI software.

Locales with weaker coverage (ain, grc, la, ko-Kore, ja-Hira, tok) used best-effort approximations following neighbouring keys' patterns; native speakers welcome to refine in follow-up PRs.

## Verified

- \`bun run paraglide:compile\` — clean
- \`bun run check\` — 0 errors (27 pre-existing warnings)
- All 32 locale files: 109 keys each
- Spot-checked ja.json: existing \`params_space_width: "空白幅"\` preserved (not overwritten)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Added/expanded translations in 40+ languages for: theme selection (system/light/dark), import confirmation dialogs, raster image scaling controls, gloss/font-size and related UI labels, and lane/remove wording.
* **Documentation**
  * Clarified contributor guidance: don’t fill unknown locale strings with English or AI guesses; leave missing keys to enable English fallback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mkpoli/word-order/pull/91?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->