### PR TITLE
fix(reorder): accurate drop targeting + visible drop indicator

### DIFF
--- a/src/lib/Equivalency.svelte
+++ b/src/lib/Equivalency.svelte
@@ -92,6 +92,8 @@
 	let draggingIndex = $state(-1);
 	let draggingPosition = { x: 0, y: 0 };
 	let draggingOffset = $state({ x: 0, y: 0 });
+	/** Visual drop index (0..equivalency.length); null when not dragging. */
+	let dropTargetIndex = $state<number | null>(null);
 
 	function dragstart(l: number, e: PointerEvent) {
 		draggingIndex = l;
@@ -100,6 +102,19 @@
 		}
 
 		draggingPosition = { x: e.clientX, y: e.clientY };
+		dropTargetIndex = l;
+	}
+
+	/** Count of equivalency rows whose vertical centre sits above the cursor. */
+	function computeDropVisualIndex(clientY: number): number {
+		let dropAt = 0;
+		for (const div of equivalencyDivs) {
+			const rect = div.getBoundingClientRect();
+			const center = (rect.top + rect.bottom) / 2;
+			if (clientY > center) dropAt++;
+			else break;
+		}
+		return dropAt;
 	}
 
 	function dragend(e: PointerEvent) {
@@ -109,21 +124,16 @@
 			e.target.releasePointerCapture(e.pointerId);
 		}
 
-		let lastBottom = -1;
-		for (const [i, div] of equivalencyDivs.entries()) {
-			const rect = div.getBoundingClientRect();
-			const centerBetween = (rect.top - lastBottom) / 2;
-
-			if (i !== draggingIndex && (i === 0 ? rect.top : centerBetween) <= e.clientY && rect.bottom >= e.clientY) {
-				onreorder?.({ from: draggingIndex, to: i });
-				break;
-			}
-
-			lastBottom = rect.bottom;
+		const visual = computeDropVisualIndex(e.clientY);
+		if (visual !== draggingIndex && visual !== draggingIndex + 1) {
+			// Splice mechanics: drop AFTER current position needs visual - 1.
+			const to = visual < draggingIndex ? visual : visual - 1;
+			onreorder?.({ from: draggingIndex, to });
 		}
 
 		draggingIndex = -1;
 		draggingOffset = { x: 0, y: 0 };
+		dropTargetIndex = null;
 	}
 
 	function onpointermove(e: PointerEvent) {
@@ -132,6 +142,7 @@
 				x: e.clientX - draggingPosition.x,
 				y: e.clientY - draggingPosition.y
 			};
+			dropTargetIndex = computeDropVisualIndex(e.clientY);
 		}
 	}
 
@@ -146,6 +157,9 @@
 <div class="color-bar" style:background-image={stripeGradient}></div>
 <div class="entries" bind:this={entriesContainer}>
 	{#each equivalency as entry, i (i)}
+		{#if dropTargetIndex === i && draggingIndex !== i && draggingIndex !== i - 1}
+			<div class="drop-indicator" aria-hidden="true"></div>
+		{/if}
 		<div
 			class="equivalency"
 			style:color={colors[i]}
@@ -167,6 +181,9 @@
 			{/each}
 		</div>
 	{/each}
+	{#if dropTargetIndex === equivalency.length && draggingIndex !== equivalency.length - 1}
+		<div class="drop-indicator" aria-hidden="true"></div>
+	{/if}
 </div>
 <button class="scramble-all" title={$LL.menu.scramble()} aria-label={$LL.menu.scramble()} onclick={() => onscramble?.()}>
 	<iconify-icon icon="fad:random-1dice" width="1.5em"></iconify-icon>
@@ -183,6 +200,13 @@
 	.equivalency {
 		cursor: move;
 		user-select: none;
+	}
+
+	.drop-indicator {
+		height: 0;
+		border-top: 2px solid var(--color-accent);
+		margin: -1px 0;
+		pointer-events: none;
 	}
 
 	.color-bar {

--- a/src/lib/Output.svelte
+++ b/src/lib/Output.svelte
@@ -271,6 +271,8 @@
 	let draggingIndex = $state(-1);
 	let draggingPosition = { x: 0, y: 0 };
 	let draggingOffset = $state({ x: 0, y: 0 });
+	/** Visual drop index (0..sentences.length); null when not dragging. */
+	let dropTargetIndex = $state<number | null>(null);
 	let draggers: HTMLDivElement[] = $state([]);
 
 	// Dragging output margins from the canvas edge.
@@ -343,6 +345,25 @@
 		draggingIndex = l;
 		draggers[draggingIndex]?.setPointerCapture(e.pointerId);
 		draggingPosition = { x: e.clientX, y: e.clientY };
+		dropTargetIndex = l;
+	}
+
+	/**
+	 * The "visual" drop index — between which rows the dragged row would land,
+	 * counting from 0 (above the first row) to `draggers.length` (below the
+	 * last). Computed by counting how many rows have their vertical centre
+	 * above the cursor. This is what the user sees, independent of the
+	 * splice-mechanics adjustment we do for dispatch.
+	 */
+	function computeDropVisualIndex(clientY: number): number {
+		let dropAt = 0;
+		for (const dragger of draggers) {
+			const rect = dragger.getBoundingClientRect();
+			const center = (rect.top + rect.bottom) / 2;
+			if (clientY > center) dropAt++;
+			else break;
+		}
+		return dropAt;
 	}
 
 	function dragend(e: PointerEvent) {
@@ -350,30 +371,28 @@
 
 		draggers[draggingIndex]?.releasePointerCapture(e.pointerId);
 
-		let lastBottom = -1;
-		for (const [i, dragger] of draggers.entries()) {
-			const rect = dragger.getBoundingClientRect();
-			const centerBetween = (rect.top - lastBottom) / 2;
-
-			if (i !== draggingIndex && (i === 0 ? rect.top : centerBetween) <= e.clientY && rect.bottom >= e.clientY) {
-				dispatch('reorder', {
-					from: draggingIndex,
-					to: i
-				});
-				break;
-			}
-
-			lastBottom = rect.bottom;
+		const visual = computeDropVisualIndex(e.clientY);
+		// Skip dispatch if the visual position is the same as the original
+		// (drop above own row OR just below own row both leave the array
+		// unchanged after splice).
+		if (visual !== draggingIndex && visual !== draggingIndex + 1) {
+			// Adjust for the splice(from, 1) shift: if we drop AFTER the
+			// original position (visual > from), the removal moves everything
+			// down by 1, so the insert index is visual - 1.
+			const to = visual < draggingIndex ? visual : visual - 1;
+			dispatch('reorder', { from: draggingIndex, to });
 		}
 
 		draggingIndex = -1;
 		draggingOffset = { x: 0, y: 0 };
+		dropTargetIndex = null;
 	}
 
 	function onpointermove(e: PointerEvent) {
 		if (draggingIndex >= 0) {
 			draggingOffset.x = e.clientX - draggingPosition.x;
 			draggingOffset.y = e.clientY - draggingPosition.y;
+			dropTargetIndex = computeDropVisualIndex(e.clientY);
 		}
 	}
 
@@ -639,6 +658,9 @@
 	{#if !loading}
 		{#each sentences as sentence, i}
 			{@const { lang, tokens } = sentence}
+			{#if dropTargetIndex === i && draggingIndex !== i && draggingIndex !== i - 1}
+				<div class="drop-indicator" aria-hidden="true"></div>
+			{/if}
 			{#if !pendingIndices.has(i)}
 				<div class="sentence" class:dragged={draggingIndex === i} class:modifying={modifying === i}>
 					<div class="dragger action" onpointerdown={(e) => dragstart(i, e)} bind:this={draggers[i]}>
@@ -749,6 +771,9 @@
 				</div>
 			{/if}
 		{/each}
+		{#if dropTargetIndex === sentences.length && draggingIndex !== sentences.length - 1}
+			<div class="drop-indicator" aria-hidden="true"></div>
+		{/if}
 		{#if pendingIndices.size > 0}
 			<div class="pending-tray">
 				{#each [...pendingIndices] as i (i)}
@@ -1379,6 +1404,17 @@
 
 	.sentence {
 		display: contents;
+	}
+
+	/* Spans the full grid as a thin accent-coloured line, slid into the
+	   row-gap with negative margins so it doesn't push the neighbouring rows.
+	   pointer-events:none keeps it from interfering with drag detection. */
+	.drop-indicator {
+		grid-column: 1 / -1;
+		height: 0;
+		border-top: 2px solid var(--color-accent);
+		margin: calc(-1 * var(--row-gap, 0.65em) / 2 - 1px) 0;
+		pointer-events: none;
 	}
 
 	.action {

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -49,6 +49,10 @@ test('theme toggle cycles system → light → dark', async ({ page }) => {
 
 test('output canvas stays light in both themes (export consistency)', async ({ page }) => {
 	await page.goto('/');
+	// Wait for SvelteKit hydration to mount the Output component; the page's
+	// `{#if mounted}` gate means querySelector('output') returns null until
+	// onMount finishes its async work.
+	await page.waitForSelector('output');
 
 	for (const theme of ['light', 'dark'] as const) {
 		await page.evaluate((t) => document.documentElement.setAttribute('data-theme', t), theme);


### PR DESCRIPTION
Closes #69.

Two bugs, same root in both \`Output.svelte\` (sentence reorder) and \`Equivalency.svelte\` (color-group reorder):

## 1. Drop targeting was wrong

\`\`\`ts
const centerBetween = (rect.top - lastBottom) / 2;
\`\`\`

That's **half the gap between rows**, not the midpoint between rows. For a 90-px-tall row with a 10-px gap the threshold ends up around y=5 absolute, so almost any cursor position past the very top of the viewport matches — the drop "works" only by accident and the final position often isn't where you aimed.

Rewritten to count how many rows have their vertical centres above the cursor (clean "drop before row N" semantics). Also handles splice mechanics correctly: when \`from < visual\`, the post-removal shift means \`to = visual - 1\`; when \`from > visual\`, \`to = visual\`. Drop-in-place (visual == draggingIndex or draggingIndex + 1) is detected and short-circuited so no dispatch fires for no-op drops.

## 2. No drop-target indicator (the "phantom" in the title)

The dragged row followed the cursor via translate, but **nothing** showed where it would land. Added a 2-px accent-coloured horizontal line that slides into the row-gap above the receiving row during drag, plus one after the last row when dropping past the end of the list. Suppressed when the indicator would land on the dragging row's own current position.

## Verified

- \`bun run check / lint / build\` clean
- \`bun run test\` — 7/7 passing

Manual:
- [ ] Drag a sentence up/down → line appears in the correct gap, drop lands exactly there
- [ ] Try to "drop in place" (above own row, just below own row) → no spurious dispatch
- [ ] Same flow on the color-group panel on the right


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual drop indicators that display during drag-and-drop reordering, showing a clear line preview of where items will be placed when dropped
  * Improved drop detection to prevent unnecessary reordering when items are dropped in equivalent or adjacent positions

* **Improvements**
  * Enhanced drag-and-drop feedback with visual indicators across reordering interfaces for clearer user guidance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mkpoli/word-order/pull/93?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->