### PR TITLE
fix(reorder): sync connector lines with drag phantom preview

### DIFF
--- a/src/lib/Equivalency.svelte
+++ b/src/lib/Equivalency.svelte
@@ -8,11 +8,39 @@
 		sentences: Sentence[];
 		equivalency: number[][][];
 		colors: string[];
+		/** Active drag preview ({from, to} as it would be emitted on drop), or null when idle. Read by the parent so it can permute the line colors live. */
+		dragPreview?: { from: number; to: number } | null;
 		onreorder?: (e: { from: number; to: number }) => void;
 		onscramble?: () => void;
 	}
 
-	let { sentences, equivalency, colors, onreorder, onscramble }: Props = $props();
+	let { sentences, equivalency, colors, dragPreview = $bindable(null), onreorder, onscramble }: Props = $props();
+
+	/**
+	 * For each logical entry index, return the positional colour it would take
+	 * after the proposed drop. Colours are positional (colours[k] = colour at
+	 * physical position k), so an entry being moved from `from` to `to` is
+	 * re-coloured to colours[to], and entries between `from` and `to` shift one
+	 * slot to absorb the gap.
+	 */
+	function applyPreviewColors(colors: string[], preview: { from: number; to: number } | null): string[] {
+		if (!preview) return colors;
+		const { from, to } = preview;
+		if (from === to || from < 0 || from >= colors.length) return colors;
+		return colors.map((_, i) => {
+			let newPos = i;
+			if (i === from) newPos = to;
+			else if (from < to && i > from && i <= to) newPos = i - 1;
+			else if (to < from && i >= to && i < from) newPos = i + 1;
+			return colors[newPos];
+		});
+	}
+
+	// Live colour preview shared by row swatches, the colour-bar gradient, and
+	// (via the bound dragPreview) the connector lines in Output.svelte. Without
+	// this, the phantom would slide to a new slot while the lines stayed at the
+	// old colour order — visually fragmented.
+	let displayColors = $derived(applyPreviewColors(colors, dragPreview));
 
 	function buildStripeGradient(colors: string[], positions: number[]): string {
 		if (colors.length === 0) return 'none';
@@ -87,13 +115,27 @@
 		tick().then(updateStripePositions);
 	});
 
-	let stripeGradient = $derived(buildStripeGradient(colors, stripePositions));
+	let stripeGradient = $derived(buildStripeGradient(displayColors, stripePositions));
 
 	let draggingIndex = $state(-1);
 	let draggingPosition = { x: 0, y: 0 };
 	let draggingOffset = $state({ x: 0, y: 0 });
 	/** Visual drop index (0..equivalency.length); null when not dragging. */
 	let dropTargetIndex = $state<number | null>(null);
+
+	/** Visual `dropTargetIndex` mapped to the post-splice `to` index `onreorder` uses. */
+	function visualToSpliceTo(visual: number, from: number): number {
+		return visual < from ? visual : Math.max(0, visual - 1);
+	}
+
+	function syncDragPreview() {
+		if (draggingIndex < 0 || dropTargetIndex === null) {
+			dragPreview = null;
+			return;
+		}
+		const to = visualToSpliceTo(dropTargetIndex, draggingIndex);
+		dragPreview = { from: draggingIndex, to };
+	}
 
 	function dragstart(l: number, e: PointerEvent) {
 		draggingIndex = l;
@@ -103,6 +145,7 @@
 
 		draggingPosition = { x: e.clientX, y: e.clientY };
 		dropTargetIndex = l;
+		syncDragPreview();
 	}
 
 	/** Count of equivalency rows whose vertical centre sits above the cursor. */
@@ -126,14 +169,13 @@
 
 		const visual = computeDropVisualIndex(e.clientY);
 		if (visual !== draggingIndex && visual !== draggingIndex + 1) {
-			// Splice mechanics: drop AFTER current position needs visual - 1.
-			const to = visual < draggingIndex ? visual : visual - 1;
-			onreorder?.({ from: draggingIndex, to });
+			onreorder?.({ from: draggingIndex, to: visualToSpliceTo(visual, draggingIndex) });
 		}
 
 		draggingIndex = -1;
 		draggingOffset = { x: 0, y: 0 };
 		dropTargetIndex = null;
+		dragPreview = null;
 	}
 
 	function onpointermove(e: PointerEvent) {
@@ -143,6 +185,7 @@
 				y: e.clientY - draggingPosition.y
 			};
 			dropTargetIndex = computeDropVisualIndex(e.clientY);
+			syncDragPreview();
 		}
 	}
 
@@ -162,7 +205,7 @@
 		{/if}
 		<div
 			class="equivalency"
-			style:color={colors[i]}
+			style:color={displayColors[i]}
 			onpointerdown={(e) => dragstart(i, e)}
 			onpointerup={dragend}
 			bind:this={equivalencyDivs[i]}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -96,6 +96,22 @@
 	const PALETTE_IDS: PaletteId[] = PALETTES.map((p) => p.id);
 	let palette: PaletteId = $state(DEFAULT_PALETTE);
 	let colors: string[] = $derived(pickNColors(equivalency.length, false, palette).map(oklchToHex));
+	// Bound by <Equivalency> while a drag is in progress; null when idle. Mirrors
+	// the {from, to} that onreorder would emit on drop, so we can pre-apply the
+	// same permutation to line colours without committing to the reorder.
+	let dragPreview: { from: number; to: number } | null = $state(null);
+	let displayColors: string[] = $derived.by(() => {
+		if (!dragPreview) return colors;
+		const { from, to } = dragPreview;
+		if (from === to || from < 0 || from >= colors.length) return colors;
+		return colors.map((_, i) => {
+			let newPos = i;
+			if (i === from) newPos = to;
+			else if (from < to && i > from && i <= to) newPos = i - 1;
+			else if (to < from && i >= to && i < from) newPos = i + 1;
+			return colors[newPos];
+		});
+	});
 	let word_spans: HTMLSpanElement[][] = $state([]);
 
 	// Parameters
@@ -1029,7 +1045,7 @@ ${svgString}
 					pendingIndices={pendingSentenceSet}
 					{alignment}
 					bind:lines
-					{colors}
+					colors={displayColors}
 					{verticalGap}
 					{lineGap}
 					{lineWidth}
@@ -1143,6 +1159,7 @@ ${svgString}
 			{sentences}
 			{equivalency}
 			{colors}
+			bind:dragPreview
 			onreorder={({ from, to }) => {
 				const entry = equivalency[from];
 				equivalency.splice(from, 1);


### PR DESCRIPTION
## Summary
Reported: while dragging an equivalency row, the phantom slid to its new slot but the connector lines + colour-bar stayed at the pre-drag colour order. The preview felt fragmented and ugly.

Now: row swatches, colour-bar gradient, and SVG connector lines all snap live to the **post-drop colour order** during the drag. Reorder is still only committed on drop, but the visual is one coherent preview from grab to release.

### How
- `Equivalency.svelte` exposes a bindable `dragPreview = { from, to } | null`, kept in sync with the existing `draggingIndex` + `dropTargetIndex` state on pointerdown/move/end. Internally, a positional-permutation helper maps each logical entry index to the colour it would take if the proposed drop happened.
- `+page.svelte` binds `dragPreview` and derives `displayColors` via the same permutation, passing those to `<Output>` so connector lines pick up the preview colours too.
- `colors` (the source array) is unchanged; only the *render-time* mapping is permuted. Drop still emits the same `onreorder({from, to})` event.

## Test plan
- [x] `bun run check` — 0 errors
- [x] `bun run lint` — clean
- [x] `bun run test` — all 7 Playwright smokes green
- [ ] Manually drag a row up and down with 3+ entries: row swatches, colour-bar, and lines all update together
- [ ] Drop on the same slot (no-op): nothing changes
- [ ] Cancel a drag (esc / outside release): preview clears