### PR TITLE
feat(output): inline-edit language label in the graphy

### DIFF
--- a/project.inlang/messages/en.json
+++ b/project.inlang/messages/en.json
@@ -35,6 +35,7 @@
 	"params_palette_cool": "Cool",
 	"params_palette_mono_blue": "Mono · blue",
 	"params_palette_mono_warm": "Mono · warm",
+	"aria_rename_language": "Click to rename this language label",
 	"aria_margin_top": "Top margin",
 	"aria_margin_bottom": "Bottom margin",
 	"aria_margin_left": "Left margin",

--- a/src/i18n/i18n-svelte.ts
+++ b/src/i18n/i18n-svelte.ts
@@ -82,7 +82,8 @@ const createLL = () => ({
 		marginTop: m.aria_margin_top,
 		marginBottom: m.aria_margin_bottom,
 		marginLeft: m.aria_margin_left,
-		marginRight: m.aria_margin_right
+		marginRight: m.aria_margin_right,
+		renameLanguage: m.aria_rename_language
 	},
 	dialog: {
 		editing: m.dialog_editing,

--- a/src/lib/Output.svelte
+++ b/src/lib/Output.svelte
@@ -40,6 +40,10 @@
 			offset: number;
 		};
 		cancelTranslate: void;
+		renameLanguage: {
+			sentence: number;
+			displayName: string | undefined;
+		};
 	}>();
 
 	interface Props {
@@ -662,11 +666,49 @@
 				<div class="drop-indicator" aria-hidden="true"></div>
 			{/if}
 			{#if !pendingIndices.has(i)}
+				{@const defaultLabel = getLanguageName(lang, $locale)}
+				{@const currentLabel = sentence.displayName ?? defaultLabel}
 				<div class="sentence" class:dragged={draggingIndex === i} class:modifying={modifying === i}>
 					<div class="dragger action" onpointerdown={(e) => dragstart(i, e)} bind:this={draggers[i]}>
 						<iconify-icon icon="material-symbols:drag-indicator" width="1.2em" height="1.2em"></iconify-icon>
 					</div>
-					<span class="tag" style:transform={getTransform(i, draggingOffset)}>{getLanguageName(lang, $locale)}</span>
+					<span class="tag" style:transform={getTransform(i, draggingOffset)}>
+						<span
+							class="tag-text"
+							class:tag-edited={sentence.displayName !== undefined}
+							contenteditable="true"
+							role="textbox"
+							tabindex="0"
+							spellcheck="false"
+							title={$LL.aria.renameLanguage()}
+							onkeydown={(e) => {
+								if (e.key === 'Enter' || e.key === 'Escape') {
+									e.preventDefault();
+									(e.currentTarget as HTMLElement).blur();
+								}
+							}}
+							onfocus={(e) => {
+								const range = document.createRange();
+								range.selectNodeContents(e.currentTarget as HTMLElement);
+								const sel = window.getSelection();
+								sel?.removeAllRanges();
+								sel?.addRange(range);
+							}}
+							onblur={(e) => {
+								const next = (e.currentTarget.textContent ?? '').trim();
+								const previous = sentence.displayName ?? defaultLabel;
+								if (next === previous) {
+									// Keep the rendered text in sync with state if the user typed
+									// then reverted — innerText might be stale whitespace otherwise.
+									e.currentTarget.textContent = previous;
+									return;
+								}
+								// Clear the override when the user types the default label or empties the field.
+								const displayName = next === '' || next === defaultLabel ? undefined : next;
+								dispatch('renameLanguage', { sentence: i, displayName });
+							}}>{currentLabel}</span
+						>
+					</span>
 					<div class="sentence-body" class:with-gloss={sentenceShowsGloss(sentence)} style:transform={getTransform(i, draggingOffset)}>
 						<span class="words" {lang} dir={getLocaleDirection(lang)} style:text-align={alignment}>
 							{#each tokens as token, j}
@@ -921,6 +963,29 @@
 		text-align: center;
 		margin-right: 2em;
 		white-space: nowrap;
+	}
+
+	.tag-text {
+		cursor: text;
+		border-radius: 0.2em;
+		padding: 0 0.15em;
+		outline: 1px dashed transparent;
+		outline-offset: 1px;
+		transition: outline-color 120ms ease;
+	}
+
+	.tag-text:hover {
+		outline-color: var(--color-border);
+	}
+
+	.tag-text:focus {
+		outline: 1px solid var(--color-accent);
+		background: var(--color-surface);
+	}
+
+	/* Subtle marker so an overridden label is recognisable at a glance. */
+	.tag-text.tag-edited {
+		font-style: italic;
 	}
 
 	.sentence-body {

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -48,9 +48,11 @@ const SCHEMA_VERSION = 1 as const;
 /* Tuple wire format                                                          */
 /* -------------------------------------------------------------------------- */
 
-type SentenceOptsT = [lanesAbove: number, lanesBelow: number, showGloss: 0 | 1];
+type SentenceOptsT =
+	| [lanesAbove: number, lanesBelow: number, showGloss: 0 | 1]
+	| [lanesAbove: number, lanesBelow: number, showGloss: 0 | 1, displayName: string];
 type TokenT = string | [text: string, above: string[], below: string[]];
-/** Opts is omitted when it would be `[0, 0, 0]` (the default — no annotation lanes). */
+/** Opts is omitted when it would be `[0, 0, 0]` (the default — no annotation lanes) and no displayName override is set. */
 type SentenceT = [lang: string, tokens: TokenT[]] | [lang: string, tokens: TokenT[], opts: SentenceOptsT];
 type DocT = [schemaVersion: 1, sentences: SentenceT[], equivalency: number[][][]];
 
@@ -87,12 +89,15 @@ function padOrTrim(arr: string[], len: number): string[] {
 function docToTuple(doc: ShareableDoc): DocT {
 	const sentences: SentenceT[] = doc.sentences.map((s) => {
 		const tokens = s.tokens.map(tokenToTuple);
-		// Elide the opts triple when it equals the default [0, 0, 0]. The common
-		// "plain row, no annotation lanes" case ends up as a 2-tuple
-		// `[lang, tokens]` — saves ~6 bytes per sentence in the JSON form, plus
-		// fewer key-less zeros to deflate.
-		if (s.lanesAbove === 0 && s.lanesBelow === 0 && !s.showGloss) return [s.lang, tokens];
-		return [s.lang, tokens, [s.lanesAbove, s.lanesBelow, s.showGloss ? 1 : 0]];
+		// Elide the opts triple when it equals the default [0, 0, 0] and there's
+		// no displayName override. The common "plain row, no annotation lanes"
+		// case ends up as a 2-tuple `[lang, tokens]` — saves ~6 bytes per
+		// sentence in the JSON form, plus fewer key-less zeros to deflate.
+		if (s.lanesAbove === 0 && s.lanesBelow === 0 && !s.showGloss && !s.displayName) return [s.lang, tokens];
+		const showG: 0 | 1 = s.showGloss ? 1 : 0;
+		return s.displayName
+			? [s.lang, tokens, [s.lanesAbove, s.lanesBelow, showG, s.displayName]]
+			: [s.lang, tokens, [s.lanesAbove, s.lanesBelow, showG]];
 	});
 	return [SCHEMA_VERSION, sentences, doc.equivalency];
 }
@@ -111,10 +116,12 @@ function tupleToDoc(t: unknown): ShareableDoc | null {
 		let lanesAbove = 0;
 		let lanesBelow = 0;
 		let showG: 0 | 1 = 0;
+		let displayName: string | undefined;
 		if (s.length >= 3) {
 			const opts = s[2];
 			if (!Array.isArray(opts) || opts.length < 3) return null;
 			[lanesAbove, lanesBelow, showG] = opts as [number, number, 0 | 1];
+			if (opts.length >= 4 && typeof opts[3] === 'string' && opts[3]) displayName = opts[3];
 		}
 		const tokens = (tokensRaw as TokenT[]).map((tk) => tupleToToken(tk, lanesAbove, lanesBelow));
 		sentences.push({
@@ -122,7 +129,8 @@ function tupleToDoc(t: unknown): ShareableDoc | null {
 			tokens,
 			lanesAbove,
 			lanesBelow,
-			showGloss: Boolean(showG)
+			showGloss: Boolean(showG),
+			...(displayName ? { displayName } : {})
 		});
 	}
 	return { schemaVersion: SCHEMA_VERSION, sentences, equivalency: equiv as number[][][] };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -18,6 +18,8 @@ export type Sentence = {
 	lanesAbove: number;
 	lanesBelow: number;
 	showGloss: boolean;
+	/** Optional override for the displayed language label. When unset, `getLanguageName(lang, locale)` is used. */
+	displayName?: string;
 };
 
 export type LegacySentence = [lang: string, words: string[]];

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1102,6 +1102,12 @@ ${svgString}
 						editingSelectionStart = word;
 						editingSelectionEnd = word + 1;
 					}}
+					on:renameLanguage={({ detail: { sentence, displayName } }) => {
+						const target = sentences[sentence];
+						if (!target) return;
+						if (displayName === undefined) delete target.displayName;
+						else target.displayName = displayName;
+					}}
 				/>
 			{/if}
 		</div>


### PR DESCRIPTION
## Summary
Closes #67.

Click the language tag next to a sentence to rename the displayed label inline:
- Dashed-underline on hover signals it's editable; focused state gets the accent ring + surface background.
- Enter/Escape commits the edit; click-away does the same.
- Empty input or typing the default label clears the override.
- Overridden labels are rendered in italic so they're recognisable at a glance.

The override is stored in a new `Sentence.displayName?: string` field, so font/direction selection still keys off the original BCP-47 `lang` code. Round-trips through the tuple share encoding via an **optional 4th slot** in `SentenceOptsT` — older share URLs without that slot decode unchanged, and new URLs without an override don't grow at all (still elide the opts tuple).

## Test plan
- [x] `bun run check` — 0 errors
- [x] `bun run lint` — clean
- [x] `bun run build` — passes
- [x] `bun run test` — all 7 Playwright smokes green
- [ ] Manually rename a language, refresh: override persists via autosave
- [ ] Copy link with override → reload: override survives
- [ ] Older share links (no displayName slot) still decode correctly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Customizable language labels: You can now rename the language label displayed for each sentence. Click on any language tag to edit it with a custom name, or clear it to restore the default language identification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mkpoli/word-order/pull/100?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->