### PR TITLE
chore: review nits from #94/#99/#100

### DIFF
--- a/src/lib/Equivalency.svelte
+++ b/src/lib/Equivalency.svelte
@@ -3,38 +3,19 @@
 	import { LL } from '../i18n/i18n-svelte';
 	import Word from './Word.svelte';
 	import type { Sentence } from './types';
+	import { applyPreviewColors, type DragPreview } from './equivalency-preview';
 
 	interface Props {
 		sentences: Sentence[];
 		equivalency: number[][][];
 		colors: string[];
 		/** Active drag preview ({from, to} as it would be emitted on drop), or null when idle. Read by the parent so it can permute the line colors live. */
-		dragPreview?: { from: number; to: number } | null;
+		dragPreview?: DragPreview;
 		onreorder?: (e: { from: number; to: number }) => void;
 		onscramble?: () => void;
 	}
 
 	let { sentences, equivalency, colors, dragPreview = $bindable(null), onreorder, onscramble }: Props = $props();
-
-	/**
-	 * For each logical entry index, return the positional colour it would take
-	 * after the proposed drop. Colours are positional (colours[k] = colour at
-	 * physical position k), so an entry being moved from `from` to `to` is
-	 * re-coloured to colours[to], and entries between `from` and `to` shift one
-	 * slot to absorb the gap.
-	 */
-	function applyPreviewColors(colors: string[], preview: { from: number; to: number } | null): string[] {
-		if (!preview) return colors;
-		const { from, to } = preview;
-		if (from === to || from < 0 || from >= colors.length) return colors;
-		return colors.map((_, i) => {
-			let newPos = i;
-			if (i === from) newPos = to;
-			else if (from < to && i > from && i <= to) newPos = i - 1;
-			else if (to < from && i >= to && i < from) newPos = i + 1;
-			return colors[newPos];
-		});
-	}
 
 	// Live colour preview shared by row swatches, the colour-bar gradient, and
 	// (via the bound dragPreview) the connector lines in Output.svelte. Without

--- a/src/lib/Output.svelte
+++ b/src/lib/Output.svelte
@@ -695,7 +695,10 @@
 								sel?.addRange(range);
 							}}
 							onblur={(e) => {
-								const next = (e.currentTarget.textContent ?? '').trim();
+								// Collapse internal whitespace so multi-line pastes don't carry hidden
+								// newlines into the data model (the tag is white-space: nowrap, so it
+								// would render fine but the stored value would still hold them).
+								const next = (e.currentTarget.textContent ?? '').replace(/\s+/g, ' ').trim();
 								const previous = sentence.displayName ?? defaultLabel;
 								if (next === previous) {
 									// Keep the rendered text in sync with state if the user typed

--- a/src/lib/SettingsDialog.svelte
+++ b/src/lib/SettingsDialog.svelte
@@ -60,6 +60,13 @@
 			const result = await p.validateKey(key, ctrl.signal);
 			if (!ctrl.signal.aborted) validation = result;
 		}, 600);
+		// Cleanup on unmount or before the effect re-runs: cancel the pending
+		// debounce timer and abort any in-flight validation so we don't leak
+		// a fetch into nowhere when the dialog closes mid-check.
+		return () => {
+			if (validationTimer) clearTimeout(validationTimer);
+			if (validationAbort) validationAbort.abort();
+		};
 	});
 
 	function close() {
@@ -334,10 +341,10 @@
 		color: var(--color-text-muted);
 	}
 	.key-status.valid {
-		color: rgb(20 130 60);
+		color: var(--color-success);
 	}
 	.key-status.invalid {
-		color: rgb(180 40 40);
+		color: var(--color-danger);
 	}
 	.key-status.network-error {
 		color: var(--color-text-muted);

--- a/src/lib/equivalency-preview.ts
+++ b/src/lib/equivalency-preview.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared drag-preview permutation.
+ *
+ * While an equivalency row is being dragged, the visual order doesn't change
+ * (the dragged row floats with the cursor; static rows stay put). What does
+ * change is the *colour* each row would take if the drop happened — colours
+ * are positional, so an entry moving from `from` → `to` is re-coloured to
+ * `colors[to]`, and entries between `from` and `to` shift one slot to absorb
+ * the gap.
+ *
+ * Both <Equivalency> (for row swatches + colour-bar) and <Output> (for SVG
+ * connector line colours, via +page.svelte's display colours) use this — so
+ * the entire preview reads as one synchronised motion instead of the phantom
+ * sliding in isolation.
+ */
+export type DragPreview = { from: number; to: number } | null;
+
+export function applyPreviewColors<T>(colors: T[], preview: DragPreview): T[] {
+	if (!preview) return colors;
+	const { from, to } = preview;
+	if (from === to || from < 0 || from >= colors.length) return colors;
+	return colors.map((_, i) => {
+		let newPos = i;
+		if (i === from) newPos = to;
+		else if (from < to && i > from && i <= to) newPos = i - 1;
+		else if (to < from && i >= to && i < from) newPos = i + 1;
+		return colors[newPos];
+	});
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -40,6 +40,8 @@
 			--color-accent: rgb(44 71 255);
 			--color-inactive: rgb(61, 66, 66);
 			--color-error: rgb(255 0 50);
+			--color-success: rgb(20 130 60);
+			--color-danger: rgb(180 40 40);
 
 			--color-bg: #ffffff;
 			--color-surface: #ffffff;
@@ -78,6 +80,8 @@
 			   dark page bg; lift to a mid-grey instead of the near-black light default. */
 			--color-inactive: rgb(170 178 188);
 			--color-accent-text: rgb(135 165 255);
+			--color-success: rgb(85 200 130);
+			--color-danger: rgb(240 110 110);
 		}
 
 		@media (prefers-color-scheme: dark) {
@@ -96,6 +100,8 @@
 				--color-shadow: rgb(0 0 0 / 0.55);
 				--color-inactive: rgb(170 178 188);
 				--color-accent-text: rgb(135 165 255);
+				--color-success: rgb(85 200 130);
+				--color-danger: rgb(240 110 110);
 			}
 		}
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,6 +2,7 @@
 	import { run } from 'svelte/legacy';
 
 	import { oklchToHex, pickNColors, DEFAULT_PALETTE, PALETTES, type PaletteId } from '$lib/color';
+	import { applyPreviewColors, type DragPreview } from '$lib/equivalency-preview';
 	import { onMount, tick } from 'svelte';
 
 	import 'iconify-icon';
@@ -99,19 +100,8 @@
 	// Bound by <Equivalency> while a drag is in progress; null when idle. Mirrors
 	// the {from, to} that onreorder would emit on drop, so we can pre-apply the
 	// same permutation to line colours without committing to the reorder.
-	let dragPreview: { from: number; to: number } | null = $state(null);
-	let displayColors: string[] = $derived.by(() => {
-		if (!dragPreview) return colors;
-		const { from, to } = dragPreview;
-		if (from === to || from < 0 || from >= colors.length) return colors;
-		return colors.map((_, i) => {
-			let newPos = i;
-			if (i === from) newPos = to;
-			else if (from < to && i > from && i <= to) newPos = i - 1;
-			else if (to < from && i >= to && i < from) newPos = i + 1;
-			return colors[newPos];
-		});
-	});
+	let dragPreview: DragPreview = $state(null);
+	let displayColors: string[] = $derived(applyPreviewColors(colors, dragPreview));
 	let word_spans: HTMLSpanElement[][] = $state([]);
 
 	// Parameters


### PR DESCRIPTION
## Summary

Follow-ups identified during the triage of #94, #99, #100 — small enough to bundle rather than block those merges on.

### #94 (LLM key validation)
- Replace hardcoded `rgb(20 130 60)` / `rgb(180 40 40)` in `.key-status` with new theme-aware `--color-success` / `--color-danger` CSS vars (light + dark variants defined in `+layout.svelte`).
- Return a cleanup from the validation `$effect` so an in-flight check aborts when the dialog closes mid-check (previously a stale fetch could update `validation` after unmount).

### #99 (drag preview sync)
- Dedupe `applyPreviewColors` into a new `src/lib/equivalency-preview.ts`. Both `Equivalency.svelte` and `+page.svelte` now import the same function and a shared `DragPreview` type, instead of inlining the permutation twice.

### #100 (inline language rename)
- Collapse internal whitespace on the rename input (`.replace(/\s+/g, ' ').trim()`) so a multi-line paste doesn't carry hidden newlines into `Sentence.displayName`. The tag is `white-space: nowrap` so rendering already hid them, but storing them was sloppy.

## Test plan
- [x] `bun run check` — 0 errors
- [x] `bun run lint` — clean
- [x] `bun run build` — passes
- [x] `bun run test` — all 7 Playwright smokes green
- [ ] Manually verify key-status colours look right in both themes
- [ ] Open settings, type a key, immediately close dialog: no console error about state-after-unmount