### PR TITLE
fix(gloss): break source-language font inheritance into annotations

### DIFF
--- a/src/lib/Output.svelte
+++ b/src/lib/Output.svelte
@@ -718,7 +718,7 @@
 								<!-- svelte-ignore a11y_click_events_have_key_events -->
 								<span class="token" class:with-gloss={sentenceShowsGloss(sentence) && isContent(word)}>
 									{#if hasAboveLanes}
-										<span class="annotations-above" style:font-size={`${glossFontSize}px`}>
+										<span class="annotations-above" lang="zxx" style:font-size={`${glossFontSize}px`}>
 											{#each Array(sentence.lanesAbove) as _, laneIndex}
 												<span class="annotation-line annotation-above">
 													{isContent(word) ? (token.annotationsAbove[laneIndex] ?? '') : ''}
@@ -773,7 +773,7 @@
 										<Word {word} />
 									</span>
 									{#if hasBelowLanes}
-										<span class="annotations-below" style:font-size={`${glossFontSize}px`}>
+										<span class="annotations-below" lang="zxx" style:font-size={`${glossFontSize}px`}>
 											{#each Array(sentence.lanesBelow) as _, laneIndex}
 												<span class="annotation-line annotation-below">
 													{isContent(word) ? (token.annotationsBelow[laneIndex] ?? '') : ''}


### PR DESCRIPTION
## Summary
Reported in #68. Annotation lanes (glosses, IPA, POS) were inheriting the parent \`<span class=\"words\" lang=\"…\">\`'s lang attribute, so a Japanese sentence's glosses rendered in a JP webfont, a Korean sentence's in a KR webfont, etc. For Leipzig-style abbreviations like \`1SG.PST.PFV\`, that's always wrong — they should render in the chosen Latin font.

Tag the annotation containers with \`lang=\"zxx\"\` (\"no linguistic content\" per BCP-47), which suppresses the browser's lang-specific font fallback while still letting the user's chosen \`fontFamily\` flow through. Glosses now render in Latin glyphs by default.

Closes #68.

## Test plan
- [x] \`bun run check\` — 0 errors
- [x] \`bun run lint\` — clean
- [x] \`bun run test\` — all 7 Playwright smokes green
- [ ] Manually: load a JP / KR / Ainu sentence with glosses, confirm the gloss text is no longer in the source-language font
- [ ] Manually: with fontFamily set to Serif / Monospace, glosses follow the choice (Latin variants)