### PR TITLE
feat(text): add letter-spacing (tracking) slider

### DIFF
--- a/project.inlang/messages/en.json
+++ b/project.inlang/messages/en.json
@@ -26,6 +26,7 @@
 	"params_font_size": "Font Size",
 	"params_gloss_font_size": "Gloss Font Size",
 	"params_space_width": "Space Width",
+	"params_letter_spacing": "Letter Spacing",
 	"params_colors": "Colors",
 	"params_palette": "Palette",
 	"params_palette_spectrum": "Full spectrum",

--- a/src/i18n/i18n-svelte.ts
+++ b/src/i18n/i18n-svelte.ts
@@ -34,6 +34,7 @@ const createLL = () => ({
 		fontSize: m.params_font_size,
 		glossFontSize: m.params_gloss_font_size,
 		spaceWidth: m.params_space_width,
+		letterSpacing: m.params_letter_spacing,
 		colors: m.params_colors,
 		palette: m.params_palette,
 		paletteNames: {

--- a/src/lib/Output.svelte
+++ b/src/lib/Output.svelte
@@ -73,6 +73,7 @@
 		fontSize: number;
 		glossFontSize: number;
 		spaceWidth: number;
+		letterSpacing?: number;
 		outputMargin?: Margin;
 		mode?: Mode;
 		output: HTMLOutputElement | undefined;
@@ -102,6 +103,7 @@
 		fontSize,
 		glossFontSize,
 		spaceWidth,
+		letterSpacing = 0,
 		outputMargin = $bindable({ top: 0, right: 0, bottom: 0, left: 0 }),
 		mode = $bindable('view'),
 		output = $bindable()
@@ -710,7 +712,7 @@
 						>
 					</span>
 					<div class="sentence-body" class:with-gloss={sentenceShowsGloss(sentence)} style:transform={getTransform(i, draggingOffset)}>
-						<span class="words" {lang} dir={getLocaleDirection(lang)} style:text-align={alignment}>
+						<span class="words" {lang} dir={getLocaleDirection(lang)} style:text-align={alignment} style:letter-spacing={`${letterSpacing}px`}>
 							{#each tokens as token, j}
 								{@const word = token.text}
 								{@const hasAboveLanes = sentence.lanesAbove > 0}

--- a/src/lib/Parameters.svelte
+++ b/src/lib/Parameters.svelte
@@ -21,6 +21,7 @@
 		fontSize?: number;
 		glossFontSize?: number;
 		spaceWidth?: number;
+		letterSpacing?: number;
 		palette?: PaletteId;
 	}
 
@@ -37,6 +38,7 @@
 		fontSize = $bindable(15),
 		glossFontSize = $bindable(11),
 		spaceWidth = $bindable(4),
+		letterSpacing = $bindable(0),
 		palette = $bindable(DEFAULT_PALETTE)
 	}: Props = $props();
 
@@ -174,6 +176,12 @@
 		{$LL.params.spaceWidth()}
 	</label>
 	<RangeSlider bind:value={spaceWidth} id="space-width" min={0} max={40} suffix=" px" />
+
+	<label for="letter-spacing">
+		<iconify-icon icon="mdi:format-letter-spacing" inline="true"></iconify-icon>
+		{$LL.params.letterSpacing()}
+	</label>
+	<RangeSlider bind:value={letterSpacing} id="letter-spacing" min={-2} max={10} step={0.1} suffix=" px" />
 </fieldset>
 
 <fieldset>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -127,6 +127,7 @@
 	let fontSize = $state(15);
 	let glossFontSize = $state(11);
 	let spaceWidth = $state(4);
+	let letterSpacing = $state(0);
 	let outputMargin: Margin = $state({ top: 40, right: 32, bottom: 40, left: 32 });
 
 	let aboutOpen = $state(false);
@@ -1107,6 +1108,7 @@ ${svgString}
 					{fontSize}
 					{glossFontSize}
 					{spaceWidth}
+					{letterSpacing}
 					bind:outputMargin
 					{loading}
 					{modifying}
@@ -1206,6 +1208,7 @@ ${svgString}
 			bind:fontSize
 			bind:glossFontSize
 			bind:spaceWidth
+			bind:letterSpacing
 			bind:palette
 		/>
 	</div>


### PR DESCRIPTION
## Summary
Closes #73. Adds a Letter Spacing slider to the Text panel — range -2 to +10 px in 0.1 px steps. Maps to CSS \`letter-spacing\` on the source-text container, so it flows into both words and glosses. Default 0, so existing diagrams render identically.

## Test plan
- [x] \`bun run check\` — 0 errors
- [x] \`bun run lint\` — clean
- [x] \`bun run test\` — all 7 Playwright smokes green
- [ ] Manually: drag slider, see words spread/compress; negative values legible too
- [ ] Manually: SVG / PNG / PDF exports keep the spacing