### PR TITLE
feat(export): add social-platform preset sizes

### DIFF
--- a/project.inlang/messages/en.json
+++ b/project.inlang/messages/en.json
@@ -84,6 +84,7 @@
 	"menu_png": "Export PNG",
 	"menu_pdf": "Export PDF",
 	"menu_raster_scale": "Raster scale:",
+	"menu_social_section": "Social presets",
 	"menu_scramble": "Scramble colors",
 	"menu_examples": "Examples",
 	"menu_about": "About",

--- a/src/i18n/i18n-svelte.ts
+++ b/src/i18n/i18n-svelte.ts
@@ -110,6 +110,7 @@ const createLL = () => ({
 		png: m.menu_png,
 		pdf: m.menu_pdf,
 		rasterScale: m.menu_raster_scale,
+		socialSection: m.menu_social_section,
 		scramble: m.menu_scramble,
 		about: m.menu_about,
 		settings: m.menu_settings,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -778,6 +778,66 @@ ${svgString}
 		}
 	}
 
+	type SocialPreset = { id: string; label: string; width: number; height: number };
+	// Sized for the platforms' link-card / in-feed image slots as of early 2026.
+	const SOCIAL_PRESETS: SocialPreset[] = [
+		{ id: 'twitter-card', label: 'X / Twitter (1600 × 900)', width: 1600, height: 900 },
+		{ id: 'instagram-square', label: 'Instagram square (1080 × 1080)', width: 1080, height: 1080 },
+		{ id: 'instagram-portrait', label: 'Instagram portrait (1080 × 1350)', width: 1080, height: 1350 },
+		{ id: 'facebook-link', label: 'Facebook link (1200 × 630)', width: 1200, height: 630 },
+		{ id: 'linkedin-link', label: 'LinkedIn link (1200 × 627)', width: 1200, height: 627 }
+	];
+
+	async function exportSocial(preset: SocialPreset) {
+		if (!output) return;
+		try {
+			// Render the natural-size PNG first, then composite onto a canvas of
+			// the preset dimensions so we don't have to fight the dom-to-image
+			// scale math for non-aspect-preserving targets.
+			const source = await exportPngBlob(2);
+			if (!source) return;
+
+			const sourceUrl = URL.createObjectURL(source);
+			try {
+				const img = new Image();
+				await new Promise<void>((resolve, reject) => {
+					img.onload = () => resolve();
+					img.onerror = () => reject(new Error('Image load failed'));
+					img.src = sourceUrl;
+				});
+
+				const canvas = document.createElement('canvas');
+				canvas.width = preset.width;
+				canvas.height = preset.height;
+				const ctx = canvas.getContext('2d');
+				if (!ctx) return;
+				ctx.fillStyle = getExportBackgroundColor();
+				ctx.fillRect(0, 0, preset.width, preset.height);
+
+				// Fit-contain with 5% padding so the diagram never kisses the edges.
+				const pad = 0.05;
+				const maxW = preset.width * (1 - pad * 2);
+				const maxH = preset.height * (1 - pad * 2);
+				const scale = Math.min(maxW / img.width, maxH / img.height);
+				const drawW = img.width * scale;
+				const drawH = img.height * scale;
+				const drawX = (preset.width - drawW) / 2;
+				const drawY = (preset.height - drawH) / 2;
+				ctx.imageSmoothingQuality = 'high';
+				ctx.drawImage(img, drawX, drawY, drawW, drawH);
+
+				const out = await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, 'image/png'));
+				if (out) save(out, 'image/png', exportFilename(`${preset.id}.png`));
+			} finally {
+				URL.revokeObjectURL(sourceUrl);
+			}
+		} catch (err) {
+			console.error(`Export social (${preset.id}) failed:`, err);
+		} finally {
+			closeExportMenu();
+		}
+	}
+
 	async function exportPdf() {
 		if (!output) {
 			closeExportMenu();
@@ -1004,6 +1064,13 @@ ${svgString}
 					{/each}
 				</select>
 			</div>
+			<div class="export-section-label">{$LL.menu.socialSection()}</div>
+			{#each SOCIAL_PRESETS as preset (preset.id)}
+				<button type="button" class="export-social" disabled={mode === 'edit'} onclick={() => exportSocial(preset)}>
+					<iconify-icon icon="mdi:share-variant-outline" inline="true"></iconify-icon>
+					{preset.label}
+				</button>
+			{/each}
 		</div>
 	</div>
 	<button class="about-button" title={$LL.menu.settings()} aria-label={$LL.menu.settings()} onclick={() => (settingsOpen = true)}>
@@ -1717,6 +1784,22 @@ ${svgString}
 	.export-scale-row label {
 		font-weight: 600;
 		white-space: nowrap;
+	}
+
+	.export-section-label {
+		padding: 0.6em 0.85em 0.25em;
+		margin-top: 0.4em;
+		border-top: 1px solid var(--color-border-soft);
+		font-size: 0.72em;
+		font-weight: 700;
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+		color: var(--color-text-faint);
+	}
+
+	.export-menu button.export-social {
+		font-weight: normal;
+		font-size: 0.92em;
 	}
 
 	.export-scale-row select {


### PR DESCRIPTION
## Summary
Closes #72. New **Social Presets** section in the Export menu with five fixed-canvas PNGs sized for the major platforms' link-card / in-feed slots:

| Preset | Size |
|---|---|
| X / Twitter | 1600 × 900 |
| Instagram square | 1080 × 1080 |
| Instagram portrait | 1080 × 1350 |
| Facebook link | 1200 × 630 |
| LinkedIn link | 1200 × 627 |

### How
- Renders the natural-size PNG once via the existing \`exportPngBlob(2)\` pipeline.
- Composites it onto a canvas of the target dimensions with **fit-contain + 5 % padding**, so the diagram never crops or kisses the edges.
- Background uses \`getExportBackgroundColor()\` so it matches the existing PNG / PDF export behaviour in both themes.
- Filename suffix includes the preset id (\`…twitter-card.png\`, \`…instagram-square.png\`, …) so you can keep multiple exports side-by-side.

## Test plan
- [x] \`bun run check\` — 0 errors
- [x] \`bun run lint\` — clean
- [x] \`bun run build\` — passes
- [x] \`bun run test\` — all 7 Playwright smokes green
- [ ] Manually: export each preset, open in Preview/Finder — dimensions exact
- [ ] Manually: drop the 1600×900 into a Twitter draft → card preview crops correctly
- [ ] Manually: very wide diagram + 1080×1350 portrait → contained, not cropped