### PR TITLE
feat(persist): unify every parameter knob into one localStorage snapshot

### DIFF
--- a/src/lib/persisted-params.ts
+++ b/src/lib/persisted-params.ts
@@ -1,0 +1,79 @@
+/**
+ * Single-key localStorage snapshot of every appearance / parameter knob in
+ * the app, so a refresh restores the user's whole setup — not just the
+ * couple of fields (rasterScale, palette, lineStyle) that used to have
+ * dedicated keys.
+ *
+ * The schema is intentionally partial: missing fields fall through to the
+ * caller's defaults instead of forcing a migration on every parameter add.
+ * Legacy keys are migrated transparently on first read, then overwritten
+ * by the unified snapshot.
+ */
+import type { Alignment, FontFamily, FontStyle, LineStyle, Margin } from './types';
+import type { PaletteId } from './color';
+
+export const PARAMS_STORAGE_KEY = 'word-order:params';
+
+const LEGACY_PALETTE_KEY = 'word-order:palette';
+const LEGACY_LINE_STYLE_KEY = 'word-order:line-style';
+const LEGACY_RASTER_SCALE_KEY = 'word-order:raster-scale';
+
+export type ParamsSnapshot = {
+	// Connector lines
+	verticalGap?: number;
+	lineGap?: number;
+	lineWidth?: number;
+	lineStyle?: LineStyle;
+	straightLength?: number;
+	endpointCorrection?: number;
+	curvature?: number;
+	// Text
+	alignment?: Alignment;
+	fontFamily?: FontFamily;
+	fontStyle?: FontStyle;
+	fontSize?: number;
+	glossFontSize?: number;
+	spaceWidth?: number;
+	letterSpacing?: number;
+	// Colours
+	palette?: PaletteId;
+	// Export / canvas
+	rasterScale?: number;
+	outputMargin?: Margin;
+};
+
+export function loadParams(): ParamsSnapshot {
+	if (typeof window === 'undefined') return {};
+	try {
+		const raw = window.localStorage.getItem(PARAMS_STORAGE_KEY);
+		if (raw) {
+			const parsed = JSON.parse(raw);
+			if (parsed && typeof parsed === 'object') return parsed as ParamsSnapshot;
+		}
+	} catch {
+		// Corrupt JSON shouldn't crash the app — fall through to legacy/empty.
+	}
+	return readLegacy();
+}
+
+export function saveParams(p: ParamsSnapshot): void {
+	if (typeof window === 'undefined') return;
+	try {
+		window.localStorage.setItem(PARAMS_STORAGE_KEY, JSON.stringify(p));
+	} catch {
+		// Quota exceeded / private-mode failure — silently drop the write
+		// rather than crashing the reactive saveDoc effect on every change.
+	}
+}
+
+function readLegacy(): ParamsSnapshot {
+	const out: ParamsSnapshot = {};
+	const palette = window.localStorage.getItem(LEGACY_PALETTE_KEY);
+	if (palette) out.palette = palette as PaletteId;
+	const lineStyle = window.localStorage.getItem(LEGACY_LINE_STYLE_KEY);
+	if (lineStyle) out.lineStyle = lineStyle as LineStyle;
+	const rasterScaleRaw = window.localStorage.getItem(LEGACY_RASTER_SCALE_KEY);
+	const rasterScale = Number(rasterScaleRaw);
+	if (rasterScaleRaw && !Number.isNaN(rasterScale)) out.rasterScale = rasterScale;
+	return out;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,6 +3,7 @@
 
 	import { oklchToHex, pickNColors, DEFAULT_PALETTE, PALETTES, type PaletteId } from '$lib/color';
 	import { applyPreviewColors, type DragPreview } from '$lib/equivalency-preview';
+	import { loadParams, saveParams } from '$lib/persisted-params';
 	import { onMount, tick } from 'svelte';
 
 	import 'iconify-icon';
@@ -94,10 +95,11 @@
 		}
 		return cm;
 	});
-	const PALETTE_STORAGE_KEY = 'word-order:palette';
 	const PALETTE_IDS: PaletteId[] = PALETTES.map((p) => p.id);
-	const LINE_STYLE_STORAGE_KEY = 'word-order:line-style';
 	const LINE_STYLES: LineStyle[] = ['solid', 'dashed', 'dotted'];
+	const ALIGNMENTS: Alignment[] = ['left', 'center', 'right'];
+	const FONT_FAMILIES: FontFamily[] = ['default', 'sans-serif', 'serif', 'monospace'];
+	const FONT_STYLES: FontStyle[] = ['normal', 'italic', 'bold', 'bold-italic'];
 	let palette: PaletteId = $state(DEFAULT_PALETTE);
 	let colors: string[] = $derived(pickNColors(equivalency.length, false, palette).map(oklchToHex));
 	// Bound by <Equivalency> while a drag is in progress; null when idle. Mirrors
@@ -131,7 +133,6 @@
 
 	type RasterScale = 2 | 3 | 4 | 6;
 	const RASTER_SCALES: RasterScale[] = [2, 3, 4, 6];
-	const RASTER_SCALE_STORAGE_KEY = 'word-order:raster-scale';
 	let rasterScale: RasterScale = $state(2);
 
 	type PendingTranslation = {
@@ -236,14 +237,36 @@
 		// connector SVG empty until the next user interaction.
 		word_spans = sentences.map(() => []);
 
-		const storedScale = Number(window.localStorage.getItem(RASTER_SCALE_STORAGE_KEY));
-		if (RASTER_SCALES.includes(storedScale as RasterScale)) rasterScale = storedScale as RasterScale;
-
-		const storedPalette = window.localStorage.getItem(PALETTE_STORAGE_KEY);
-		if (storedPalette && PALETTE_IDS.includes(storedPalette as PaletteId)) palette = storedPalette as PaletteId;
-
-		const storedLineStyle = window.localStorage.getItem(LINE_STYLE_STORAGE_KEY);
-		if (storedLineStyle && LINE_STYLES.includes(storedLineStyle as LineStyle)) lineStyle = storedLineStyle as LineStyle;
+		// Unified persisted parameter snapshot: replaces the per-key reads
+		// (raster scale, palette, line style) and adds restore for every
+		// other appearance / text / margin knob the user touches. Values are
+		// guarded with explicit shape/enum checks so a hand-edited or
+		// corrupt blob can't crash the page.
+		const stored = loadParams();
+		if (typeof stored.verticalGap === 'number') verticalGap = stored.verticalGap;
+		if (typeof stored.lineGap === 'number') lineGap = stored.lineGap;
+		if (typeof stored.lineWidth === 'number') lineWidth = stored.lineWidth;
+		if (stored.lineStyle && LINE_STYLES.includes(stored.lineStyle)) lineStyle = stored.lineStyle;
+		if (typeof stored.straightLength === 'number') straightLength = stored.straightLength;
+		if (typeof stored.endpointCorrection === 'number') endpointCorrection = stored.endpointCorrection;
+		if (typeof stored.curvature === 'number') curvature = stored.curvature;
+		if (stored.alignment && ALIGNMENTS.includes(stored.alignment)) alignment = stored.alignment;
+		if (stored.fontFamily && FONT_FAMILIES.includes(stored.fontFamily)) fontFamily = stored.fontFamily;
+		if (stored.fontStyle && FONT_STYLES.includes(stored.fontStyle)) fontStyle = stored.fontStyle;
+		if (typeof stored.fontSize === 'number') fontSize = stored.fontSize;
+		if (typeof stored.glossFontSize === 'number') glossFontSize = stored.glossFontSize;
+		if (typeof stored.spaceWidth === 'number') spaceWidth = stored.spaceWidth;
+		if (typeof stored.letterSpacing === 'number') letterSpacing = stored.letterSpacing;
+		if (stored.palette && PALETTE_IDS.includes(stored.palette)) palette = stored.palette;
+		if (typeof stored.rasterScale === 'number' && RASTER_SCALES.includes(stored.rasterScale as RasterScale)) {
+			rasterScale = stored.rasterScale as RasterScale;
+		}
+		if (stored.outputMargin && typeof stored.outputMargin === 'object') {
+			const m = stored.outputMargin;
+			if (typeof m.top === 'number' && typeof m.right === 'number' && typeof m.bottom === 'number' && typeof m.left === 'number') {
+				outputMargin = m;
+			}
+		}
 
 		mounted = true;
 		await tick();
@@ -946,14 +969,30 @@ ${svgString}
 		equivalency = equivalency.filter((entry) => !entry.every((sentence) => sentence.length === 0));
 	});
 	let pendingSentenceSet = $derived(new Set<number>(pendingTranslation?.rowIndices ?? []));
+	// Persist every appearance / parameter knob in a single localStorage
+	// blob so the next visit restores the user's full setup, not just the
+	// three fields that used to have dedicated keys.
 	run(() => {
-		if (mounted) window.localStorage.setItem(RASTER_SCALE_STORAGE_KEY, String(rasterScale));
-	});
-	run(() => {
-		if (mounted) window.localStorage.setItem(PALETTE_STORAGE_KEY, palette);
-	});
-	run(() => {
-		if (mounted) window.localStorage.setItem(LINE_STYLE_STORAGE_KEY, lineStyle);
+		if (!mounted) return;
+		saveParams({
+			verticalGap,
+			lineGap,
+			lineWidth,
+			lineStyle,
+			straightLength,
+			endpointCorrection,
+			curvature,
+			alignment,
+			fontFamily,
+			fontStyle,
+			fontSize,
+			glossFontSize,
+			spaceWidth,
+			letterSpacing,
+			palette,
+			rasterScale,
+			outputMargin
+		});
 	});
 	// Autosave on any change to sentences or equivalency. Skip while a translation is pending
 	// so we don't persist the empty placeholder rows.


### PR DESCRIPTION
## Summary
Closes #53. Today only \`rasterScale\`, \`palette\`, and \`lineStyle\` are persisted — everything else (vertical gap, line gap, line width, straight length, endpoint correction, curvature, alignment, font family, font style, font size, gloss font size, space width, letter spacing, output margin) resets to defaults on every reload. That's annoying.

This consolidates the lot into a single \`word-order:params\` blob via a new \`src/lib/persisted-params.ts\` module:
- One JSON snapshot, one autosave \`run\` effect.
- Per-field enum/shape guards on read so a corrupt or hand-edited blob can't crash the page.
- Legacy fallback: if the new key is absent, reads the three old standalone keys (\`word-order:raster-scale\`, \`word-order:palette\`, \`word-order:line-style\`) so existing users keep their saved values on first load. After the next change they'll be migrated to the unified blob.
- The new \`saveParams\` / \`loadParams\` swallow \`localStorage\` errors (quota / private mode) silently — the doc-autosave \`run\` block already in this region shouldn't be allowed to crash on a parameter tweak.

## Test plan
- [x] \`bun run check\` — 0 errors
- [x] \`bun run lint\` — clean
- [x] \`bun run build\` — passes
- [x] \`bun run test\` — all 7 Playwright smokes green
- [ ] Manually: drag every slider, reload, all values restore
- [ ] Manually: existing user with only the legacy keys → reload, settings preserved
- [ ] Manually: \`localStorage.setItem('word-order:params', 'garbage')\` → page still loads, defaults applied