### PR TITLE
feat(lines): add halo option for legible crossings (#4)

### DIFF
--- a/project.inlang/messages/en.json
+++ b/project.inlang/messages/en.json
@@ -11,6 +11,8 @@
 	"params_line_style_solid": "Solid",
 	"params_line_style_dashed": "Dashed",
 	"params_line_style_dotted": "Dotted",
+	"params_line_halo": "Halo",
+	"params_line_halo_on": "Highlight crossings",
 	"params_straight_length": "Straight Part",
 	"params_endpoint_correction": "Endpoint Correction",
 	"params_curvature": "Curvature",

--- a/src/i18n/i18n-svelte.ts
+++ b/src/i18n/i18n-svelte.ts
@@ -19,6 +19,8 @@ const createLL = () => ({
 		lineStyleSolid: m.params_line_style_solid,
 		lineStyleDashed: m.params_line_style_dashed,
 		lineStyleDotted: m.params_line_style_dotted,
+		lineHalo: m.params_line_halo,
+		lineHaloOn: m.params_line_halo_on,
 		straightLength: m.params_straight_length,
 		endpointCorrection: m.params_endpoint_correction,
 		curvature: m.params_curvature,

--- a/src/lib/Output.svelte
+++ b/src/lib/Output.svelte
@@ -65,6 +65,8 @@
 		lineGap: number;
 		lineWidth?: number;
 		lineStyle?: LineStyle;
+		lineHalo?: boolean;
+		lineHaloWidth?: number;
 		straightLength: number;
 		endpointCorrection: number;
 		curvature?: number;
@@ -96,6 +98,8 @@
 		lineGap,
 		lineWidth = 1,
 		lineStyle = 'solid',
+		lineHalo = false,
+		lineHaloWidth = 1.5,
 		straightLength,
 		endpointCorrection,
 		curvature = 1,
@@ -929,6 +933,22 @@
 		{@const dashArray =
 			lineStyle === 'dashed' ? `${lineWidth * 5} ${lineWidth * 4}` : lineStyle === 'dotted' ? `${lineWidth} ${lineWidth * 2}` : undefined}
 		<svg style="position: absolute;" width="100%" height="100%">
+			<!-- Halo pass: a thicker background-coloured stroke drawn under each
+			     coloured stroke. When two paths cross, the upper one's halo masks
+			     a small slice of the lower one — the "subway-map" technique that
+			     makes dense crossings legible without changing path geometry. -->
+			{#if lineHalo}
+				{#each lines as [x1, y1, x2, y2]}
+					<path
+						class="line-halo"
+						d={connectionPath(x1, y1, x2, y2, curvature)}
+						stroke-width={lineWidth + lineHaloWidth * 2}
+						stroke-dasharray={dashArray}
+						stroke-linecap="round"
+						fill="none"
+					/>
+				{/each}
+			{/if}
 			{#each lines as [x1, y1, x2, y2, color]}
 				<path
 					d={connectionPath(x1, y1, x2, y2, curvature)}
@@ -1084,6 +1104,14 @@
 		   dom-to-svg, shifting exports off-centre to the right. Centring is
 		   handled by the .output-scroll wrapper instead. */
 		flex-shrink: 0;
+	}
+
+	/* Halo strokes mask crossings by painting in the canvas background colour.
+	   The output element overrides --color-bg to white (so PNG / SVG / PDF
+	   exports stay consistent regardless of theme), so this var resolves
+	   correctly in both interactive and export contexts. */
+	.line-halo {
+		stroke: var(--color-bg, white);
 	}
 
 	svg {

--- a/src/lib/Parameters.svelte
+++ b/src/lib/Parameters.svelte
@@ -13,6 +13,8 @@
 		lineGap?: number;
 		lineWidth?: number;
 		lineStyle?: LineStyle;
+		lineHalo?: boolean;
+		lineHaloWidth?: number;
 		straightLength?: number;
 		endpointCorrection?: number;
 		curvature?: number;
@@ -31,6 +33,8 @@
 		lineGap = $bindable(5),
 		lineWidth = $bindable(1),
 		lineStyle = $bindable('solid'),
+		lineHalo = $bindable(false),
+		lineHaloWidth = $bindable(1.5),
 		straightLength = $bindable(0),
 		endpointCorrection = $bindable(0),
 		curvature = $bindable(1),
@@ -102,6 +106,18 @@
 		<option value="dashed">{$LL.params.lineStyleDashed()}</option>
 		<option value="dotted">{$LL.params.lineStyleDotted()}</option>
 	</select>
+
+	<label for="line-halo">
+		<iconify-icon icon="mdi:circle-double" inline="true"></iconify-icon>
+		{$LL.params.lineHalo()}
+	</label>
+	<div class="halo-row">
+		<label class="halo-toggle">
+			<input type="checkbox" id="line-halo" bind:checked={lineHalo} />
+			<span>{$LL.params.lineHaloOn()}</span>
+		</label>
+		<RangeSlider id="line-halo-width" min={0.5} max={4} step={0.1} bind:value={lineHaloWidth} suffix=" px" disabled={!lineHalo} />
+	</div>
 
 	<label for="straight-length">
 		<iconify-icon icon="material-symbols:subdirectory-arrow-right" inline="true"></iconify-icon>
@@ -221,6 +237,25 @@
 </fieldset>
 
 <style>
+	.halo-row {
+		display: grid;
+		grid-template-columns: auto 1fr;
+		align-items: center;
+		gap: 0.6em;
+		margin: 0 0.5em;
+	}
+
+	.halo-toggle {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35em;
+		font-weight: normal;
+		font-size: 0.92em;
+		color: var(--color-text-muted);
+		cursor: pointer;
+		white-space: nowrap;
+	}
+
 	.alignment {
 		display: grid;
 		grid-template-columns: 1fr 1fr 1fr;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -112,6 +112,8 @@
 	let lineGap = $state(0);
 	let lineWidth = $state(1);
 	let lineStyle: LineStyle = $state('solid');
+	let lineHalo = $state(false);
+	let lineHaloWidth = $state(1.5);
 	let straightLength = $state(0);
 	let endpointCorrection = $state(0);
 	let curvature = $state(1);
@@ -1250,6 +1252,8 @@ ${svgString}
 					{lineGap}
 					{lineWidth}
 					{lineStyle}
+					{lineHalo}
+					{lineHaloWidth}
 					{straightLength}
 					{endpointCorrection}
 					{curvature}
@@ -1350,6 +1354,8 @@ ${svgString}
 			bind:lineGap
 			bind:lineWidth
 			bind:lineStyle
+			bind:lineHalo
+			bind:lineHaloWidth
 			bind:straightLength
 			bind:endpointCorrection
 			bind:curvature


### PR DESCRIPTION
## Summary
Addresses #4 (the article it links to discusses techniques for making dense crossing lines legible).

Adds a **Halo** toggle in the Parameters panel: when on, each coloured line is drawn on top of a thicker background-coloured stroke, so where two paths cross the upper one's halo cleanly masks a small slice of the lower one — the standard "subway-map" technique. No geometry change, just an extra render pass per line.

Two new parameters:
- \`lineHalo\` (boolean, default off — zero visual change for existing diagrams)
- \`lineHaloWidth\` (px, default 1.5, range 0.5..4) — slider is disabled while halo is off

Halo stroke colour resolves to \`var(--color-bg)\`, which the \`<output>\` element overrides to white regardless of theme, so the masking works identically in interactive light/dark mode AND in SVG / PNG / PDF exports.

### Open follow-up
This PR wires the param through Output / Parameters / +page but does **not** persist it. #110 (unified params snapshot) needs to land first; once it does, a one-line patch will add \`lineHalo\` + \`lineHaloWidth\` to the snapshot.

## Test plan
- [x] \`bun run check\` — 0 errors
- [x] \`bun run lint\` — clean
- [x] \`bun run build\` — passes
- [x] \`bun run test\` — all 7 Playwright smokes green
- [ ] Manually: load a dense diagram (many crossings) → toggle halo, crossings become unambiguous
- [ ] Manually: export SVG / PNG / PDF with halo on → masking preserved
- [ ] Manually: halo width slider only enabled when toggle is on