### PR TITLE
fix(reorder): animate non-dragged rows to make room for the phantom

### DIFF
--- a/src/lib/Equivalency.svelte
+++ b/src/lib/Equivalency.svelte
@@ -170,10 +170,33 @@
 		}
 	}
 
-	function getTransform(l: number, draggingOffset: { x: number; y: number }) {
-		if (draggingIndex !== l) return 'none';
-		return `translate(${draggingOffset.x}px, ${draggingOffset.y}px)`;
+	function getTransform(l: number, draggingOffset: { x: number; y: number }, shifts: number[]) {
+		if (draggingIndex === l) {
+			return `translate(${draggingOffset.x}px, ${draggingOffset.y}px)`;
+		}
+		const shift = shifts[l] ?? 0;
+		return shift ? `translateY(${shift}px)` : 'none';
 	}
+
+	// While dragging, non-dragged rows that sit between the source slot and the
+	// proposed drop slot slide out of the way by the dragged row's height — so
+	// the phantom doesn't visually overlap their text, and the user sees a live
+	// preview of the post-drop layout instead of a row floating over a static
+	// column. Empty array when idle so the rows render in their natural slots.
+	let displayShifts: number[] = $derived.by(() => {
+		const shifts = equivalency.map(() => 0);
+		if (!dragPreview || equivalencyDivs.length === 0) return shifts;
+		const { from, to } = dragPreview;
+		if (from === to || from < 0 || from >= equivalencyDivs.length) return shifts;
+		const draggedHeight = equivalencyDivs[from]?.offsetHeight ?? 0;
+		if (draggedHeight === 0) return shifts;
+		for (let i = 0; i < shifts.length; i++) {
+			if (i === from) continue;
+			if (from < to && i > from && i <= to) shifts[i] = -draggedHeight;
+			else if (to < from && i >= to && i < from) shifts[i] = draggedHeight;
+		}
+		return shifts;
+	});
 </script>
 
 <svelte:window onpointerup={dragend} {onpointermove} />
@@ -186,11 +209,12 @@
 		{/if}
 		<div
 			class="equivalency"
+			class:dragging={draggingIndex === i}
 			style:color={displayColors[i]}
 			onpointerdown={(e) => dragstart(i, e)}
 			onpointerup={dragend}
 			bind:this={equivalencyDivs[i]}
-			style:transform={getTransform(i, draggingOffset)}
+			style:transform={getTransform(i, draggingOffset, displayShifts)}
 		>
 			{#each entry as words, j (j)}
 				<span class="words">
@@ -224,6 +248,19 @@
 	.equivalency {
 		cursor: move;
 		user-select: none;
+		/* Non-dragged rows shift out of the way (see displayShifts) — animate
+		   that transform so the preview reads as a smooth swap rather than
+		   teleport. The active drag opts out below so the phantom tracks the
+		   cursor without lag. */
+		transition: transform 180ms cubic-bezier(0.2, 0.8, 0.2, 1);
+	}
+
+	.equivalency.dragging {
+		transition: none;
+		/* Lift the phantom above the row it's hovering over so the colour
+		   tag isn't visually under another row's text mid-drag. */
+		z-index: 1;
+		position: relative;
 	}
 
 	.drop-indicator {


### PR DESCRIPTION
## Summary
Follow-up to #99. Reported: the dragged phantom in the equivalency panel was sliding over the text of static rows beneath it — connector lines didn't move, but the phantom's text and the row underneath's text overlapped visually. #99 fixed the colour preview, but didn't make the column reflow.

This adds the missing motion: while a drag is active, each non-dragged row that sits between the source slot and the proposed drop slot translates by the dragged row's height in the appropriate direction. With a 180ms ease transition, the result reads as a smooth swap rather than a teleport.

### Details
- Computed in a single \`displayShifts\` derived array — same indexing convention as \`displayColors\`.
- Dragged row gets \`class:dragging\` which disables the transition (so the phantom tracks the cursor without lag) and applies \`z-index: 1\` so the colour tag visibly floats above whatever row it's currently hovering.
- Drop indicator (the thin accent line) keeps its existing zero-height position, so the indicator marks the logical drop slot while the surrounding rows visually shift out of its way.

## Test plan
- [x] \`bun run check\` — 0 errors
- [x] \`bun run lint\` — clean
- [x] \`bun run test\` — all 7 Playwright smokes green
- [ ] Manually: drag a row in a 5+ row equivalency panel — rows shift smoothly, no overlap
- [ ] Manually: drag past the bottom / top edges — phantom still floats, no jitter
- [ ] Manually: quick back-and-forth drag — transitions follow without flicker
- [ ] Variable row heights: works correctly when rows differ in height


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved drag-and-drop row animations with smoother transitions when reordering items.
  * Enhanced visual feedback and positioning of dragged rows with clearer distinction from adjacent rows.
  * Better visual effects showing how rows shift during drag-and-drop interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mkpoli/word-order/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->