### PR TITLE
fix(lines): redraw connectors when letter-spacing changes

### DIFF
--- a/src/lib/Output.svelte
+++ b/src/lib/Output.svelte
@@ -473,6 +473,7 @@
 			fontSize !== undefined &&
 			glossFontSize !== undefined &&
 			spaceWidth !== undefined &&
+			letterSpacing !== undefined &&
 			$locale
 		)
 			tick().then(() => {


### PR DESCRIPTION
## Summary
Bug report: changing the Letter Spacing slider (added in #104) shifted the source words but the SVG connector lines stayed at the pre-spacing positions, so they drifted off the words and could overlap text.

Root cause: the typography-redraw effect lists \`alignment / fontFamily / fontStyle / fontSize / glossFontSize / spaceWidth / \$locale\` as its reactive guard, but I forgot to add \`letterSpacing\` when I introduced the slider. So the effect didn't re-run, \`getBoundingClientRect()\` was never re-measured, and the lines kept their old endpoints.

One-line fix: include \`letterSpacing\` in the guard.

## Test plan
- [x] \`bun run check\` — 0 errors
- [x] \`bun run lint\` — clean
- [x] \`bun run test\` — all 7 Playwright smokes green
- [ ] Manually: drag the Letter Spacing slider — connectors track the moving word centres