### PR TITLE
fix(menu): move Copy link + QR into the Export dropdown

### DIFF
--- a/project.inlang/messages/en.json
+++ b/project.inlang/messages/en.json
@@ -97,6 +97,8 @@
 	"menu_pdf": "Export PDF",
 	"menu_raster_scale": "Raster scale:",
 	"menu_social_section": "Social presets",
+	"menu_share_section": "Share",
+	"menu_file_section": "File",
 	"menu_scramble": "Scramble colors",
 	"menu_examples": "Examples",
 	"menu_about": "About",

--- a/src/i18n/i18n-svelte.ts
+++ b/src/i18n/i18n-svelte.ts
@@ -123,6 +123,8 @@ const createLL = () => ({
 		pdf: m.menu_pdf,
 		rasterScale: m.menu_raster_scale,
 		socialSection: m.menu_social_section,
+		shareSection: m.menu_share_section,
+		fileSection: m.menu_file_section,
 		scramble: m.menu_scramble,
 		about: m.menu_about,
 		settings: m.menu_settings,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1077,23 +1077,6 @@ ${svgString}
 		<iconify-icon icon="uil:import"></iconify-icon>
 		{$LL.menu.import()}</button
 	>
-	<button
-		disabled={mode === 'edit'}
-		class:share-long={shareFeedback === 'long'}
-		title={shareFeedback === 'long'
-			? $LL.menu.shareLong({ length: shareUrlLength })
-			: shareFeedback === 'copied'
-				? $LL.menu.shareCopied()
-				: $LL.menu.share()}
-		onclick={copyShareLink}
-	>
-		<iconify-icon icon={shareFeedback === 'long' ? 'mdi:alert-outline' : shareFeedback === 'copied' ? 'mdi:check' : 'mdi:link-variant'}
-		></iconify-icon>
-		{shareFeedback === 'long' ? $LL.menu.shareLongShort() : shareFeedback === 'copied' ? $LL.menu.shareCopied() : $LL.menu.share()}
-	</button>
-	<button class="qr-button" disabled={mode === 'edit'} title={$LL.menu.qr()} aria-label={$LL.menu.qr()} onclick={openQrDialog}>
-		<iconify-icon icon="mdi:qrcode"></iconify-icon>
-	</button>
 	<!-- svelte-ignore a11y_no_static_element_interactions -->
 	<div class="export-dropdown" class:open={exportOpen} bind:this={exportWrapper} onmouseenter={openExportMenu} onmouseleave={scheduleExportClose}>
 		<button
@@ -1110,6 +1093,29 @@ ${svgString}
 			<iconify-icon icon="mdi:chevron-down" inline="true" class="chevron"></iconify-icon>
 		</button>
 		<div class="export-menu" role="group" aria-label={$LL.menu.export()}>
+			<div class="export-section-label">{$LL.menu.shareSection()}</div>
+			<button
+				type="button"
+				class:share-long={shareFeedback === 'long'}
+				disabled={mode === 'edit'}
+				title={shareFeedback === 'long'
+					? $LL.menu.shareLong({ length: shareUrlLength })
+					: shareFeedback === 'copied'
+						? $LL.menu.shareCopied()
+						: $LL.menu.share()}
+				onclick={copyShareLink}
+			>
+				<iconify-icon
+					icon={shareFeedback === 'long' ? 'mdi:alert-outline' : shareFeedback === 'copied' ? 'mdi:check' : 'mdi:link-variant'}
+					inline="true"
+				></iconify-icon>
+				{shareFeedback === 'long' ? $LL.menu.shareLongShort() : shareFeedback === 'copied' ? $LL.menu.shareCopied() : $LL.menu.share()}
+			</button>
+			<button type="button" disabled={mode === 'edit'} onclick={openQrDialog}>
+				<iconify-icon icon="mdi:qrcode" inline="true"></iconify-icon>
+				{$LL.menu.qr()}
+			</button>
+			<div class="export-section-label">{$LL.menu.fileSection()}</div>
 			<button type="button" disabled={mode === 'edit'} onclick={exportJson}>
 				<iconify-icon icon="mdi:code-braces" inline="true"></iconify-icon>
 				JSON
@@ -1780,12 +1786,6 @@ ${svgString}
 		border-color: var(--color-border);
 	}
 
-	/* QR is icon-only; trim the wide padding so it sits flush next to the
-	   Copy Link button without looking oversized. */
-	.menu button.qr-button {
-		padding: 0.5em 0.6em;
-	}
-
 	.export-dropdown {
 		position: relative;
 		display: inline-flex;
@@ -1888,6 +1888,14 @@ ${svgString}
 		letter-spacing: 0.06em;
 		text-transform: uppercase;
 		color: var(--color-text-faint);
+	}
+
+	/* The first label in the menu sits flush against the top padding — no
+	   horizontal rule needed before it. */
+	.export-section-label:first-child {
+		margin-top: 0;
+		padding-top: 0.1em;
+		border-top: none;
 	}
 
 	.export-menu button.export-social {

--- a/tests/share.test.ts
+++ b/tests/share.test.ts
@@ -16,6 +16,9 @@ test.describe('URL share', () => {
 		expect(defaultMarker).toBeTruthy();
 		expect(defaultMarker).toMatch(/eat\s*glass/);
 
+		// Copy link now lives inside the Export dropdown — focusing the trigger
+		// opens the menu (it expands on focus and hover).
+		await page.getByRole('button', { name: /Export/i }).focus();
 		// Trigger the Copy link button.
 		await page.getByRole('button', { name: /Copy link|Copied/i }).click();
 		// Wait for the share handler to finish — it writes to the clipboard,


### PR DESCRIPTION
## Summary
Reported: the top toolbar (New, Import, Copy link, QR, Export ▼, Settings, About, Theme, Locale) got cluttered after #105 added the QR button. Both Copy link and QR are conceptually share/export actions, so this consolidates them into the Export dropdown.

### New Export menu layout
- **Share** — Copy link, QR code
- **File** — JSON, TSV, Text, SVG, PNG, PDF, HTML, [raster scale]
- **Social presets** — 5 fixed-size PNGs

### New top toolbar
New, Import, Export ▼, Settings, About, Theme, Locale — five primary buttons, one dropdown. Much calmer.

### Details
- Section labels use the existing \`.export-section-label\` style; a \`:first-child\` variant removes the top border on the first label so it sits flush against the menu's top padding.
- \`Copy link\` keeps its full feedback states (default / Copied! / long-URL warning) inside the dropdown, including the existing toast.
- Removed the now-unused \`.menu button.qr-button\` style.
- \`share.test.ts\` adjusted: focuses the Export trigger before clicking Copy link, since the button is now inside the dropdown.

## Test plan
- [x] \`bun run check\` — 0 errors
- [x] \`bun run lint\` — clean
- [x] \`bun run build\` — passes
- [x] \`bun run test\` — all 7 Playwright smokes green (updated share test passes)
- [ ] Manually: hover Export → Share section appears at top, File below, Social Presets below that
- [ ] Manually: click Copy link inside the dropdown → URL updates, "Copied!" feedback shows
- [ ] Manually: click QR inside the dropdown → QR dialog opens