### PR TITLE
fix(output): keep sentences on one line on narrow screens

### DIFF
--- a/src/lib/Output.svelte
+++ b/src/lib/Output.svelte
@@ -1010,6 +1010,12 @@
 
 	.words {
 		display: block;
+		/* Keep each sentence on a single line. On narrow viewports the
+		   parent <.output-scroll> provides horizontal scrolling — that
+		   gives the diagram a clean overflow story rather than wrapping
+		   words to a new line (which dropped the SVG connectors out of
+		   alignment with the tokens). */
+		white-space: nowrap;
 	}
 
 	.token {


### PR DESCRIPTION
## Summary
Reported: even after recent small-screen fixes the diagram still breaks on narrow viewports because the words wrap to multiple lines and the SVG connectors fall out of alignment.

Root cause: \`.words\` had \`display: block\` with no \`white-space: nowrap\`, so when the viewport became narrower than the sentence's natural width, tokens wrapped to a new line. \`getBoundingClientRect()\` reflected the wrapped layout (multiple rect heights, kinked positions) but the connector geometry assumed a single-line strip — endpoints landed in the wrong row.

One-line fix: add \`white-space: nowrap\` to \`.words\`. The existing \`.output-scroll\` wrapper (\`overflow-x: auto\`, flex-centered) already provides horizontal scrolling, so narrow viewports get a scrollable diagram instead of a broken one. That matches the user's "or hori scroll or sth" preference.

I considered the alternatives:
- **min-width on \`<output>\`**: would also work, but \`fit-content\` + nowrap is simpler and avoids guessing a magic width.
- **\`transform: scale(0.7)\` on small screens**: blurs raster export and breaks token-level interactions (hover targets shrink to sub-pixel). Skipped.

## Test plan
- [x] \`bun run check\` — 0 errors
- [x] \`bun run lint\` — clean
- [x] \`bun run build\` — passes
- [x] \`bun run test\` — all 7 Playwright smokes green
- [ ] Manually: shrink browser to ~400px — sentence stays on one line, horizontal scroll appears, connectors stay aligned
- [ ] Manually: scroll horizontally — words and connectors move together
- [ ] Manually: export SVG/PNG with a wide diagram → no wrapping in the export either