### PR TITLE
feat(persist): add lineHalo / lineHaloWidth / tokenGap to the snapshot

### DIFF
--- a/src/lib/persisted-params.ts
+++ b/src/lib/persisted-params.ts
@@ -24,6 +24,9 @@ export type ParamsSnapshot = {
 	lineGap?: number;
 	lineWidth?: number;
 	lineStyle?: LineStyle;
+	lineHalo?: boolean;
+	lineHaloWidth?: number;
+	tokenGap?: number;
 	straightLength?: number;
 	endpointCorrection?: number;
 	curvature?: number;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -254,6 +254,9 @@
 		if (typeof stored.lineGap === 'number') lineGap = stored.lineGap;
 		if (typeof stored.lineWidth === 'number') lineWidth = stored.lineWidth;
 		if (stored.lineStyle && LINE_STYLES.includes(stored.lineStyle)) lineStyle = stored.lineStyle;
+		if (typeof stored.lineHalo === 'boolean') lineHalo = stored.lineHalo;
+		if (typeof stored.lineHaloWidth === 'number') lineHaloWidth = stored.lineHaloWidth;
+		if (typeof stored.tokenGap === 'number') tokenGap = stored.tokenGap;
 		if (typeof stored.straightLength === 'number') straightLength = stored.straightLength;
 		if (typeof stored.endpointCorrection === 'number') endpointCorrection = stored.endpointCorrection;
 		if (typeof stored.curvature === 'number') curvature = stored.curvature;
@@ -996,6 +999,9 @@ ${svgString}
 			lineGap,
 			lineWidth,
 			lineStyle,
+			lineHalo,
+			lineHaloWidth,
+			tokenGap,
 			straightLength,
 			endpointCorrection,
 			curvature,


### PR DESCRIPTION
## Summary
Follow-up after #110 (unified params persistence), #111 (line halo), and #116 (token gap) all merged. None of the three new fields were in \`ParamsSnapshot\`, so the user's halo toggle, halo width slider, and token-gap slider were all resetting to defaults on every reload.

This adds the three fields to the snapshot type, the load-side restore guards, and the save-side blob. One file each, three new lines per file.

## Test plan
- [x] \`bun run check\` — 0 errors
- [x] \`bun run lint\` — clean
- [x] \`bun run test\` — all 7 Playwright smokes green
- [ ] Manually: toggle halo on, set halo width and token gap, reload — all three persist