### PR TITLE
feat(layout): fit diagram to container (margins → zoom)

### DIFF
--- a/src/lib/Output.svelte
+++ b/src/lib/Output.svelte
@@ -88,6 +88,10 @@
 		outputMargin?: Margin;
 		mode?: Mode;
 		output: HTMLOutputElement | undefined;
+		/** When true, suspends the fit-to-width adjustments — set during export
+		 * pipelines so the captured artifact uses the user-configured margins
+		 * and 1:1 scale rather than the shrunk on-screen presentation. */
+		fitDisabled?: boolean;
 	}
 
 	let {
@@ -121,14 +125,91 @@
 		tokenGap = 0,
 		outputMargin = $bindable({ top: 0, right: 0, bottom: 0, left: 0 }),
 		mode = $bindable('view'),
-		output = $bindable()
+		output = $bindable(),
+		fitDisabled = false
 	}: Props = $props();
 	let tokenEditDialog: HTMLDivElement | undefined = $state();
 
 	let mounted = $state(false);
 
+	// Fit-to-width: when the natural diagram is wider than its scroll
+	// container, first shrink the horizontal margins (user-configured padding
+	// of <output>) down to zero, and if that's still not enough apply CSS zoom
+	// so the whole diagram visually fits without horizontal scrolling. Both
+	// adjustments are reactive on container size + content geometry and are
+	// suspended via `fitDisabled` during exports so artifacts keep the
+	// configured margins and natural 1:1 scale.
+	let fitZoom = $state(1);
+	let fitPadX = $state<number | null>(null);
+	let fitObserver: ResizeObserver | null = null;
+
+	function recomputeFit() {
+		if (fitDisabled || !output) {
+			fitZoom = 1;
+			fitPadX = null;
+			return;
+		}
+		const parent = output.parentElement;
+		if (!parent) return;
+		const container = parent.clientWidth;
+		if (container <= 0) return;
+		// Measure natural width at 1:1 with the user's configured margins.
+		// We temporarily strip our overrides so scrollWidth reflects the
+		// real intrinsic content size, then restore the inline styles.
+		const savedPadding = output.style.padding;
+		// Cast to any so TS doesn't trip on the (now standard) zoom property.
+		const styleAny = output.style as CSSStyleDeclaration & { zoom: string };
+		const savedZoom = styleAny.zoom;
+		output.style.padding = `${outputMargin.top}px ${outputMargin.right}px ${outputMargin.bottom}px ${outputMargin.left}px`;
+		styleAny.zoom = '1';
+		const natural = output.scrollWidth;
+		output.style.padding = savedPadding;
+		styleAny.zoom = savedZoom;
+		if (natural <= container) {
+			fitZoom = 1;
+			fitPadX = null;
+			return;
+		}
+		const noPad = natural - outputMargin.left - outputMargin.right;
+		if (noPad <= container) {
+			// Shrinking horizontal padding alone makes it fit.
+			fitPadX = Math.max(0, Math.floor((container - noPad) / 2));
+			fitZoom = 1;
+		} else {
+			// Zero out horizontal padding AND zoom down to fit.
+			fitPadX = 0;
+			fitZoom = container / noPad;
+		}
+	}
+
 	onMount(() => {
 		mounted = true;
+		if (output) {
+			const parent = output.parentElement;
+			if (parent) {
+				fitObserver = new ResizeObserver(() => recomputeFit());
+				fitObserver.observe(parent);
+				fitObserver.observe(output);
+			}
+		}
+		return () => {
+			fitObserver?.disconnect();
+			fitObserver = null;
+		};
+	});
+
+	$effect(() => {
+		// Re-run fit when anything that affects natural width changes.
+		void sentences;
+		void outputMargin;
+		void fontSize;
+		void verticalGap;
+		void letterSpacing;
+		void spaceWidth;
+		void tokenGap;
+		void fitDisabled;
+		if (!mounted) return;
+		requestAnimationFrame(recomputeFit);
 	});
 
 	function drawLines(
@@ -178,10 +259,15 @@
 						const bLeft = Math.min(rectB1.left, rectB2.left);
 						const bRight = Math.max(rectB1.right, rectB2.right);
 
-						let x1 = (aLeft + aRight) / 2 - rectOutput.left;
-						let y1 = getBottomEndpoint(sentences[j], spanA1, spanA2, rectOutput);
-						let x2 = (bLeft + bRight) / 2 - rectOutput.left;
-						let y2 = getTopEndpoint(sentences[k], spanB1, spanB2, rectOutput);
+						// CSS zoom on <output> scales all child bounding-rect deltas by
+						// the zoom factor, but the SVG inside the same zoomed parent
+						// interprets path coords in pre-zoom local units. Divide here to
+						// get back to local units so the rendered lines stay glued to
+						// the words they connect.
+						let x1 = ((aLeft + aRight) / 2 - rectOutput.left) / fitZoom;
+						let y1 = getBottomEndpoint(sentences[j], spanA1, spanA2, rectOutput) / fitZoom;
+						let x2 = ((bLeft + bRight) / 2 - rectOutput.left) / fitZoom;
+						let y2 = getTopEndpoint(sentences[k], spanB1, spanB2, rectOutput) / fitZoom;
 
 						const correction = endpointCorrection / ((y2 - y1) / (x2 - x1));
 						x1 += correction;
@@ -475,6 +561,9 @@
 	}
 
 	run(() => {
+		// fitZoom referenced so a fit-driven layout change (resize / margin
+		// shrink / zoom apply) re-runs drawLines under the new scale.
+		void fitZoom;
 		if (mounted && equivalency && !loading) lines = drawLines(word_spans, equivalency, verticalGap, lineGap, straightLength, endpointCorrection);
 	});
 	run(() => {
@@ -560,7 +649,10 @@
 	class:bold={fontStyle === 'bold' || fontStyle === 'bold-italic'}
 	style:gap={`${verticalGap}px 1em`}
 	style:font-size={`${fontSize}px`}
-	style:padding={`${outputMargin.top}px ${outputMargin.right}px ${outputMargin.bottom}px ${outputMargin.left}px`}
+	style:padding={fitPadX !== null
+		? `${outputMargin.top}px ${fitPadX}px ${outputMargin.bottom}px ${fitPadX}px`
+		: `${outputMargin.top}px ${outputMargin.right}px ${outputMargin.bottom}px ${outputMargin.left}px`}
+	style:zoom={fitZoom < 1 ? fitZoom : null}
 	class:margin-adjusting={marginDrag !== null}
 >
 	<!-- Visual bands (pink tint + blueprint dimension annotation). Non-

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -130,6 +130,22 @@
 	let tokenGap = $state(0);
 	let outputMargin: Margin = $state({ top: 40, right: 32, bottom: 40, left: 32 });
 
+	// Suspends the Output fit-to-width adjustments around an export so the
+	// captured artifact uses the user-configured margins and 1:1 scale rather
+	// than the on-screen shrunk presentation. Toggled by withFitDisabled().
+	let fitDisabled = $state(false);
+	async function withFitDisabled<T>(fn: () => Promise<T>): Promise<T> {
+		fitDisabled = true;
+		await tick();
+		// One extra frame so ResizeObserver/measure pass settles before capture.
+		await new Promise((r) => requestAnimationFrame(() => r(null)));
+		try {
+			return await fn();
+		} finally {
+			fitDisabled = false;
+		}
+	}
+
 	let aboutOpen = $state(false);
 	let settingsOpen = $state(false);
 	let examplesOpen = $state(false);
@@ -729,14 +745,17 @@
 
 	async function exportPngBlob(scale = 2): Promise<Blob | null> {
 		if (!output) return null;
-		return await domToImage.toBlob(output, {
-			width: output.clientWidth * scale,
-			height: output.clientHeight * scale,
-			style: {
-				transform: `scale(${scale})`,
-				transformOrigin: 'top left',
-				'background-color': getExportBackgroundColor()
-			}
+		return await withFitDisabled(async () => {
+			if (!output) return null;
+			return await domToImage.toBlob(output, {
+				width: output.clientWidth * scale,
+				height: output.clientHeight * scale,
+				style: {
+					transform: `scale(${scale})`,
+					transformOrigin: 'top left',
+					'background-color': getExportBackgroundColor()
+				}
+			});
 		});
 	}
 
@@ -811,8 +830,8 @@
 		return serializer.serializeToString(svgDocument);
 	}
 
-	function exportSvg() {
-		const svgString = buildSvgString();
+	async function exportSvg() {
+		const svgString = await withFitDisabled(async () => buildSvgString());
 		if (svgString === null) {
 			closeExportMenu();
 			return;
@@ -821,8 +840,8 @@
 		closeExportMenu();
 	}
 
-	function exportHtml() {
-		const svgString = buildSvgString();
+	async function exportHtml() {
+		const svgString = await withFitDisabled(async () => buildSvgString());
 		if (svgString === null) {
 			closeExportMenu();
 			return;
@@ -945,42 +964,47 @@ ${svgString}
 			return;
 		}
 		try {
-			const widthPx = output.clientWidth;
-			const heightPx = output.clientHeight;
-			const orientation = widthPx >= heightPx ? 'landscape' : 'portrait';
-			const pdf = new jsPDF({
-				orientation,
-				unit: 'px',
-				format: [widthPx, heightPx],
-				hotfixes: ['px_scaling']
-			});
-
-			// Vector PDF: render via the same dom-to-svg pipeline as Export SVG,
-			// then hand the SVG element to svg2pdf so text stays selectable and
-			// lines stay crisp at any zoom (vs. the prior raster-embed PNG).
-			const svgString = buildSvgString();
-			if (!svgString) throw new Error('SVG serialisation failed');
-			const svgDoc = new DOMParser().parseFromString(svgString, 'image/svg+xml');
-			const svgRoot = svgDoc.documentElement as unknown as SVGSVGElement;
-			// svg2pdf walks the live DOM, so attach the SVG off-screen for layout.
-			// Visibility hidden but still in flow so getComputedStyle resolves.
-			const host = document.createElement('div');
-			host.style.cssText = 'position:absolute;left:-99999px;top:0;visibility:hidden;';
-			host.appendChild(svgRoot);
-			document.body.appendChild(host);
-			try {
-				const { svg2pdf } = await import('svg2pdf.js');
-				await svg2pdf(svgRoot, pdf, { x: 0, y: 0, width: widthPx, height: heightPx });
-			} finally {
-				host.remove();
-			}
-
-			pdf.save(exportFilename('pdf'));
+			await withFitDisabled(async () => exportPdfInner());
 		} catch (err) {
 			console.error('Export PDF failed:', err);
 		} finally {
 			closeExportMenu();
 		}
+	}
+
+	async function exportPdfInner() {
+		if (!output) return;
+		const widthPx = output.clientWidth;
+		const heightPx = output.clientHeight;
+		const orientation = widthPx >= heightPx ? 'landscape' : 'portrait';
+		const pdf = new jsPDF({
+			orientation,
+			unit: 'px',
+			format: [widthPx, heightPx],
+			hotfixes: ['px_scaling']
+		});
+
+		// Vector PDF: render via the same dom-to-svg pipeline as Export SVG,
+		// then hand the SVG element to svg2pdf so text stays selectable and
+		// lines stay crisp at any zoom (vs. the prior raster-embed PNG).
+		const svgString = buildSvgString();
+		if (!svgString) throw new Error('SVG serialisation failed');
+		const svgDoc = new DOMParser().parseFromString(svgString, 'image/svg+xml');
+		const svgRoot = svgDoc.documentElement as unknown as SVGSVGElement;
+		// svg2pdf walks the live DOM, so attach the SVG off-screen for layout.
+		// Visibility hidden but still in flow so getComputedStyle resolves.
+		const host = document.createElement('div');
+		host.style.cssText = 'position:absolute;left:-99999px;top:0;visibility:hidden;';
+		host.appendChild(svgRoot);
+		document.body.appendChild(host);
+		try {
+			const { svg2pdf } = await import('svg2pdf.js');
+			await svg2pdf(svgRoot, pdf, { x: 0, y: 0, width: widthPx, height: heightPx });
+		} finally {
+			host.remove();
+		}
+
+		pdf.save(exportFilename('pdf'));
 	}
 
 	let output: HTMLOutputElement | undefined = $state();
@@ -1344,6 +1368,7 @@ ${svgString}
 					{letterSpacing}
 					{tokenGap}
 					bind:outputMargin
+					{fitDisabled}
 					{loading}
 					{modifying}
 					{editingSelectionStart}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1824,6 +1824,24 @@ ${svgString}
 		}
 	}
 
+	/* On narrow viewports the page-edge padding eats space the diagram could
+	   otherwise use before fit-to-width has to zoom it down. Drop the main
+	   padding progressively so the diagram gets the full viewport width to
+	   work with before the CSS-zoom stage of the fit pipeline kicks in. */
+	@media (max-width: 720px) {
+		main {
+			padding: 0.5em;
+			gap: 1em;
+		}
+	}
+
+	@media (max-width: 480px) {
+		main {
+			padding: 0.25em;
+			gap: 0.75em;
+		}
+	}
+
 	.menu {
 		display: flex;
 		flex-wrap: wrap;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1693,14 +1693,15 @@ ${svgString}
 			0 0 0 1px var(--page-border-soft, #eeeeee);
 	}
 
-	/* Horizontal scroll lives on this inner wrapper, not on .output itself,
-	   so .output's overflow stays visible and the ::after editing indicator
-	   below the box can render. Padding gives the inner <output>'s rim shadow
-	   room to render before .output-scroll's overflow clips it. */
+	/* `overflow-x: hidden` rather than `auto` now that Output.svelte's fit
+	   pipeline guarantees the diagram never visually exceeds this container's
+	   width (margins shrink first, then CSS zoom). The horizontal scrollbar
+	   used to show up even when fit had reduced the content to the container
+	   size — sub-pixel rounding kept browsers reserving the scrollbar gutter.
+	   The flex centring stays so a narrower diagram still centres horizontally. */
 	.output-scroll {
-		overflow-x: auto;
+		overflow-x: hidden;
 		overflow-y: hidden;
-		-webkit-overflow-scrolling: touch;
 		overscroll-behavior-x: contain;
 		/* Centre the <output> when it fits; the flex container still scrolls
 		   horizontally when the diagram exceeds the viewport because the inner


### PR DESCRIPTION
## Summary

Instead of just scrolling horizontally when the diagram is wider than its container (#119 only addressed wrapping), progressively fit it to fit the viewport. Two stages, applied only to the on-screen presentation:

1. **Shrink horizontal padding** — if the diagram fits with the user's left/right margins zeroed out, the margins are auto-reduced down to whatever amount actually fits (clamped at 0). Top/bottom margins are untouched.
2. **CSS zoom** — if the diagram still overflows after zero side padding, the whole `<output>` zooms by `container / contentWidth` so it visually fits.

State stays unchanged — the user's configured margins are preserved; only the *rendered* `<output>` is shrunk via inline `style:padding` / `style:zoom`.

## Reactivity

- `ResizeObserver` watches the `<output>` and its scroll parent.
- A `$effect` re-runs the fit whenever anything that affects natural width changes (sentences, fontSize, gaps, margins, letter spacing, token gap).
- `drawLines` divides bounding-rect offsets by `fitZoom` so SVG path coords stay in pre-zoom local units → connectors stay glued to the words they link under any fit ratio.

## Export safety

A `fitDisabled` prop on `Output`, plus a `withFitDisabled(fn)` helper in `+page.svelte`, suspend the fit around captures:

- `exportPng` / `exportSocial` (dom-to-image)
- `exportSvg` / `exportHtml` (dom-to-svg)
- `exportPdf` (svg2pdf)

So PNG / SVG / HTML / PDF artifacts are always at 1:1 with the user's configured margins, never the shrunk on-screen presentation.

## Test plan

- [ ] Resize the browser narrower than the diagram's natural width — margins shrink, then zoom kicks in. No horizontal scroll.
- [ ] Connector lines stay aligned with words at every fit ratio.
- [ ] Drag a margin out at the wider viewport, then resize narrow: the user's margin is preserved (still wide), only the rendered margin is squeezed.
- [ ] Export PNG / SVG / PDF at a narrow viewport — captured artifact uses the user-set margins and is rendered at 1:1.
- [ ] Mobile (sub-400px viewport): the diagram fits without scrolling; tapping/dragging on tokens still works.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic fit-to-width layout adjustment that eliminates horizontal scrolling in rendered output

* **Improvements**
  * Enhanced export quality and reliability for PNG, SVG, HTML, and PDF formats with optimized rendering
  * Improved responsive spacing and padding for narrow viewports

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mkpoli/word-order/pull/130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->