### PR TITLE
feat(input): Cmd/Ctrl+Enter submits the sentence

### DIFF
--- a/src/lib/SentenceInput.svelte
+++ b/src/lib/SentenceInput.svelte
@@ -84,6 +84,24 @@
 		});
 	}
 
+	function submit() {
+		const w = getWords(text);
+		if (w.length === 0) {
+			empty = true;
+			return;
+		}
+		text = '';
+		const nextAbove = fitLanes(annotationsAbove, w.length);
+		const nextBelow = fitLanes(annotationsBelow, w.length);
+		dispatch('submit', {
+			lang,
+			words: w,
+			annotationsAbove: nextAbove,
+			annotationsBelow: nextBelow,
+			showGloss: glossEnabled || hasAnyLane
+		});
+	}
+
 	function syncLanes(value: string) {
 		const words = getWords(value);
 		const nextAbove = fitLanes(annotationsAbove, words.length);
@@ -142,6 +160,12 @@
 	let glossableTokens = $derived(words.map((word, tokenIndex) => ({ word, tokenIndex })).filter(({ word }) => isGlossableToken(word)));
 	let reversedAboveIndices = $derived(annotationsAbove.map((_, i) => i).reverse());
 	let hasAnyLane = $derived(annotationsAbove.length > 0 || annotationsBelow.length > 0);
+
+	// Platform-aware modifier glyph for the submit shortcut hint shown on the
+	// primary button's tooltip. Not a translatable string — ⌘ / Ctrl are
+	// universal keycap notation.
+	const isMac = typeof navigator !== 'undefined' && /Mac|iP(hone|ad|od)/.test(navigator.platform || navigator.userAgent || '');
+	let submitShortcutHint = $derived(`${modifying === -1 ? $LL.input.add() : $LL.input.modify()} · ${isMac ? '⌘' : 'Ctrl'}+Enter`);
 </script>
 
 <fieldset class:editing={modifying !== -1}>
@@ -158,6 +182,14 @@
 			bind:this={textArea}
 			onchange={() => {
 				empty = false;
+			}}
+			onkeydown={(e) => {
+				// Cmd/Ctrl+Enter submits without leaving the keyboard — a plain
+				// Enter still inserts a newline (sentences can span lines).
+				if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+					e.preventDefault();
+					submit();
+				}
 			}}
 		></textarea>
 		<details class="gloss-panel" bind:open={glossEnabled}>
@@ -243,26 +275,7 @@
 			<input type="text" bind:value={lang} id="lang" />
 			<label for="lang">{displayName}</label>
 			<div class="primary-actions">
-				<button
-					class="primary"
-					onclick={() => {
-						const w = getWords(text);
-						if (w.length === 0) {
-							empty = true;
-							return;
-						}
-						text = '';
-						const nextAbove = fitLanes(annotationsAbove, w.length);
-						const nextBelow = fitLanes(annotationsBelow, w.length);
-						dispatch('submit', {
-							lang,
-							words: w,
-							annotationsAbove: nextAbove,
-							annotationsBelow: nextBelow,
-							showGloss: glossEnabled || hasAnyLane
-						});
-					}}
-				>
+				<button class="primary" title={submitShortcutHint} onclick={submit}>
 					<iconify-icon icon={modifying === -1 ? 'ic:round-plus' : 'material-symbols:edit-rounded'} width="1.3em" height="1.3em"></iconify-icon>
 					{modifying === -1 ? $LL.input.add() : $LL.input.modify()}
 				</button>


### PR DESCRIPTION
## Summary

The Add / Modify action was mouse-only. Adds the standard **Cmd/Ctrl+Enter** shortcut from the input textarea so users can add a sentence without reaching for the mouse. A plain Enter still inserts a newline (a sentence can span multiple lines), so this is purely additive.

- Extracted the inline button handler into a `submit()` function shared by the primary button and the textarea keydown — identical behaviour on both paths (empty-input guard, lane fitting, reset).
- The primary button's tooltip now shows the shortcut, platform-aware (⌘+Enter on macOS, Ctrl+Enter elsewhere). The label stays translated; the keycap notation (⌘ / Ctrl) is universal, so no new i18n string.

## Test plan
- [ ] Type a sentence, press ⌘/Ctrl+Enter → it's added; textarea clears.
- [ ] Plain Enter → newline inserted, not submitted.
- [ ] Empty input + ⌘/Ctrl+Enter → shows the empty-state hint, doesn't dispatch.
- [ ] Works the same in Modify mode.
- [ ] Tooltip shows ⌘+Enter on macOS, Ctrl+Enter elsewhere.