### PR TITLE
a11y: close dialogs on backdrop-only click; drop legacy bubbler

### DIFF
--- a/src/lib/AboutDialog.svelte
+++ b/src/lib/AboutDialog.svelte
@@ -1,7 +1,4 @@
 <script lang="ts">
-	import { createBubbler, stopPropagation } from 'svelte/legacy';
-
-	const bubble = createBubbler();
 	import { LL } from '../i18n/i18n-svelte';
 
 	interface Props {
@@ -22,8 +19,12 @@
 <svelte:window {onkeydown} />
 
 {#if open}
-	<div class="backdrop" onclick={close} role="presentation">
-		<div class="dialog" role="dialog" aria-modal="true" aria-labelledby="about-title" onclick={stopPropagation(bubble('click'))}>
+	<!-- Close only when the backdrop itself is clicked, not when a click bubbles
+	     up from inside the dialog. Avoids the legacy stopPropagation bubbler on
+	     the dialog (which tripped the a11y "non-interactive element with click
+	     handler" rule). -->
+	<div class="backdrop" onclick={(e) => e.target === e.currentTarget && close()} role="presentation">
+		<div class="dialog" role="dialog" aria-modal="true" aria-labelledby="about-title">
 			<header>
 				<h2 id="about-title">
 					<iconify-icon icon="mdi:information-outline" inline="true"></iconify-icon>

--- a/src/lib/SettingsDialog.svelte
+++ b/src/lib/SettingsDialog.svelte
@@ -1,7 +1,4 @@
 <script lang="ts">
-	import { createBubbler, stopPropagation } from 'svelte/legacy';
-
-	const bubble = createBubbler();
 	import { LL } from '../i18n/i18n-svelte';
 	import { llmSettings, type ProviderId } from './settings';
 	import { PROVIDERS, getProvider } from './llm/providers';
@@ -99,8 +96,9 @@
 <svelte:window {onkeydown} />
 
 {#if open}
-	<div class="backdrop" onclick={close} role="presentation">
-		<div class="dialog" role="dialog" aria-modal="true" aria-labelledby="settings-title" onclick={stopPropagation(bubble('click'))}>
+	<!-- Close only on a direct backdrop click — see AboutDialog for rationale. -->
+	<div class="backdrop" onclick={(e) => e.target === e.currentTarget && close()} role="presentation">
+		<div class="dialog" role="dialog" aria-modal="true" aria-labelledby="settings-title">
 			<header>
 				<h2 id="settings-title">
 					<iconify-icon icon="mdi:cog-outline" inline="true"></iconify-icon>

--- a/src/lib/TranslatePopover.svelte
+++ b/src/lib/TranslatePopover.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-	import { run, createBubbler, stopPropagation } from 'svelte/legacy';
+	import { run } from 'svelte/legacy';
 
-	const bubble = createBubbler();
 	import { createEventDispatcher } from 'svelte';
 	import { SvelteSet } from 'svelte/reactivity';
 	import { LL, locale } from '../i18n/i18n-svelte';
@@ -34,7 +33,9 @@
 	let sourceSummary = $derived(sourceLangs.map((l) => getLanguageName(l, $locale)).join(', '));
 
 	// "selected" can hold both known locale codes and ad-hoc custom BCP-47 codes.
-	let selected: SvelteSet<string> = new SvelteSet();
+	// SvelteSet is reactive on its own — mutate it in place (add/delete/clear)
+	// and never reassign, so no $state wrapper and no manual self-assignment.
+	const selected: SvelteSet<string> = new SvelteSet();
 	let initializedFor = $state('');
 	let customCode = $state('');
 
@@ -44,7 +45,8 @@
 			const baseDefaults = [String($locale), ...DEFAULT_TARGETS]
 				.filter((v) => v && !sourceLangSet.has(v))
 				.filter((v) => options.some((o) => o.value === v));
-			selected = new SvelteSet(baseDefaults);
+			selected.clear();
+			for (const v of baseDefaults) selected.add(v);
 			initializedFor = signature;
 			customCode = '';
 		}
@@ -57,7 +59,6 @@
 	function toggle(value: string) {
 		if (selected.has(value)) selected.delete(value);
 		else selected.add(value);
-		selected = selected;
 	}
 
 	function addCustom() {
@@ -65,7 +66,6 @@
 		if (!v) return;
 		if (sourceLangSet.has(v)) return;
 		selected.add(v);
-		selected = selected;
 		customCode = '';
 	}
 
@@ -92,8 +92,9 @@
 <svelte:window {onkeydown} />
 
 {#if open}
-	<div class="backdrop" onclick={() => dispatch('close')} role="presentation">
-		<div class="popover" role="dialog" aria-modal="true" aria-labelledby="translate-popover-title" onclick={stopPropagation(bubble('click'))}>
+	<!-- Close only on a direct backdrop click — see AboutDialog for rationale. -->
+	<div class="backdrop" onclick={(e) => e.target === e.currentTarget && dispatch('close')} role="presentation">
+		<div class="popover" role="dialog" aria-modal="true" aria-labelledby="translate-popover-title">
 			<header>
 				<h2 id="translate-popover-title">
 					<iconify-icon icon="mdi:translate" inline="true"></iconify-icon>


### PR DESCRIPTION
## Summary

Cleans up an a11y warning shared by the three modal dialogs (About, Settings, Translate) and fixes a latent reactivity bug found along the way.

### Dialog close pattern
Each dialog closed via a backdrop `onclick`, with a `stopPropagation(bubble('click'))` on the inner `role="dialog"` element to stop inside-clicks from bubbling to the backdrop. That put a click handler on a non-interactive element → svelte-check a11y warnings.

Replaced with the standard pattern: the backdrop closes **only when the click target is the backdrop itself** (`e.target === e.currentTarget`). Inside-clicks never reach it, so no `stopPropagation`, no `createBubbler` import. Escape-to-close (already present via `svelte:window`) is unchanged.

### Bonus reactivity fix (TranslatePopover)
`selected` was a reactive `SvelteSet` but declared with plain `let` and **reassigned** on reset (`selected = new SvelteSet(...)`) — so the reset didn't reliably trigger a re-render (svelte-check flagged it). Now it's mutated in place (`clear()` + `add()`), never reassigned, so it's reactive without a `$state` wrapper (which `SvelteSet` doesn't need), and the redundant `selected = selected` self-assignments are gone.

**svelte-check warnings: 33 → 26.**

## Test plan
- [ ] Open each dialog → click inside (on text/inputs) → stays open.
- [ ] Click the dim backdrop → closes.
- [ ] Esc → closes.
- [ ] Translate popover: open → default targets selected; toggle some; reopen after changing source langs → selection resets correctly.