### PR TITLE
a11y: ARIA roles for drag-reorder list and slider track

### DIFF
--- a/src/lib/Equivalency.svelte
+++ b/src/lib/Equivalency.svelte
@@ -202,7 +202,7 @@
 <svelte:window onpointerup={dragend} {onpointermove} />
 
 <div class="color-bar" style:background-image={stripeGradient}></div>
-<div class="entries" bind:this={entriesContainer}>
+<div class="entries" bind:this={entriesContainer} role="list">
 	{#each equivalency as entry, i (i)}
 		{#if dropTargetIndex === i && draggingIndex !== i && draggingIndex !== i - 1}
 			<div class="drop-indicator" aria-hidden="true"></div>
@@ -215,6 +215,7 @@
 			onpointerup={dragend}
 			bind:this={equivalencyDivs[i]}
 			style:transform={getTransform(i, draggingOffset, displayShifts)}
+			role="listitem"
 		>
 			{#each entry as words, j (j)}
 				<span class="words">

--- a/src/lib/ui/RangeSlider.svelte
+++ b/src/lib/ui/RangeSlider.svelte
@@ -232,6 +232,7 @@
 	class:hoverable
 	class:reversed
 	class:focus
+	role="none"
 	onmousedown={sliderInteractStart}
 	onmouseup={sliderInteractEnd}
 	ontouchstart={preventDefault(sliderInteractStart)}


### PR DESCRIPTION
## What

Silences svelte's `a11y_no_static_element_interactions` on the two custom interaction widgets by giving them honest ARIA roles. No behavioural or visual change.

- **`Equivalency.svelte`** — the equivalency rows are a draggable, reorderable list. The container now carries `role="list"` and each draggable row `role="listitem"`. These use *pointer* handlers (`onpointerdown`/`onpointerup`), so the keyboard-event rule (`a11y_click_events_have_key_events`) doesn't apply.
- **`ui/RangeSlider.svelte`** — the outer track `<div>` handles mouse/touch to seek, but the focusable handle `<span>` child already carries `role="slider"` with `aria-valuemin/max/now` and full keyboard support (`sliderKeydown`). The track is therefore presentational, so it gets `role="none"` (a second `slider` role would be wrong).

## Why

These files are untouched by the other open PRs, so this is conflict-safe. Continues the a11y sweep (after #139).

## Test plan

- [x] `bun run check` — warnings 33 → 31 (both target warnings gone, 0 errors)
- [x] `bun run lint` — prettier + eslint clean
- [x] `bun test src/lib/` — 29 pass
- [ ] Manual: drag to reorder equivalency rows still works; slider drag/click/keyboard still works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced semantic markup and ARIA attributes across components for improved accessibility support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mkpoli/word-order/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->