### PR TITLE
a11y(qr): close QR dialog on backdrop-only click

### DIFF
--- a/src/lib/QrDialog.svelte
+++ b/src/lib/QrDialog.svelte
@@ -109,8 +109,9 @@
 <svelte:window {onkeydown} />
 
 {#if open}
-	<div class="backdrop" onclick={close} role="presentation">
-		<div class="dialog" role="dialog" aria-modal="true" aria-labelledby="qr-title" onclick={(e) => e.stopPropagation()}>
+	<!-- Close only on a direct backdrop click — see AboutDialog for rationale. -->
+	<div class="backdrop" onclick={(e) => e.target === e.currentTarget && close()} role="presentation">
+		<div class="dialog" role="dialog" aria-modal="true" aria-labelledby="qr-title">
 			<header>
 				<h2 id="qr-title">
 					<iconify-icon icon="mdi:qrcode" inline="true"></iconify-icon>


### PR DESCRIPTION
## What

Brings `QrDialog` in line with the backdrop-close pattern adopted in #139 for the other dialogs.

Previously the backdrop used `onclick={close}` (closes on *any* bubbled click) and the inner dialog blocked that with `onclick={(e) => e.stopPropagation()}`. That `stopPropagation` handler sat on the `role="dialog"` element and tripped two a11y warnings:
- *Elements with the 'dialog' interactive role must have a tabindex value*
- *Visible, non-interactive elements with a click event must be accompanied by a keyboard event handler*

Now the backdrop closes only when it is itself the click target (`e.target === e.currentTarget`), and the inner click handler is removed. Escape-to-close is unchanged.

## Why

Conflict-safe: `QrDialog.svelte` is untouched by every other open PR. Continues the a11y sweep.

## Test plan

- [x] `bun run check` — warnings 33 → 31 (both QrDialog warnings gone, 0 errors)
- [x] `bun run lint` — clean
- [x] `bun test src/lib/` — 29 pass
- [ ] Manual: clicking the backdrop closes the QR dialog; clicking inside (on the QR / URL row) does not; Escape closes