### PR TITLE
test: cover tokenizeSentence and parseRuby (#50)

### DIFF
--- a/src/lib/ruby.test.ts
+++ b/src/lib/ruby.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'bun:test';
+import { parseRuby, rubyRule } from './ruby';
+
+describe('parseRuby', () => {
+	it('splits base text and reading from a well-formed ruby tag', () => {
+		expect(parseRuby('<ruby>漢<rt>かん</rt></ruby>')).toEqual({ rb: '漢', rt: 'かん' });
+	});
+
+	it('handles multi-character base and reading', () => {
+		expect(parseRuby('<ruby>東京<rt>とうきょう</rt></ruby>')).toEqual({ rb: '東京', rt: 'とうきょう' });
+	});
+
+	it('tolerates a missing closing </rt> tag', () => {
+		// The regex makes the closing </rt> optional: ...(?:<\/rt>)*...
+		expect(parseRuby('<ruby>漢<rt>かん</ruby>')).toEqual({ rb: '漢', rt: 'かん' });
+	});
+
+	it('returns the warning sentinel for non-ruby input', () => {
+		expect(parseRuby('plain text')).toEqual({ rb: '⚠', rt: '⚠' });
+	});
+
+	it('returns the warning sentinel for an empty string', () => {
+		expect(parseRuby('')).toEqual({ rb: '⚠', rt: '⚠' });
+	});
+
+	it('returns the warning sentinel when the base or reading is empty', () => {
+		// [^<]+ requires at least one character in each slot.
+		expect(parseRuby('<ruby><rt>かん</rt></ruby>')).toEqual({ rb: '⚠', rt: '⚠' });
+		expect(parseRuby('<ruby>漢<rt></rt></ruby>')).toEqual({ rb: '⚠', rt: '⚠' });
+	});
+});
+
+describe('rubyRule', () => {
+	it('matches a ruby tag anywhere in the string', () => {
+		expect(rubyRule.test('foo <ruby>漢<rt>かん</rt></ruby> bar')).toBe(true);
+	});
+
+	it('does not match plain text', () => {
+		expect(rubyRule.test('no ruby here')).toBe(false);
+	});
+
+	it('captures the ruby tag when used to split', () => {
+		// The capturing group keeps the delimiter in String.prototype.split output.
+		expect('a<ruby>x<rt>y</rt></ruby>b'.split(rubyRule)).toEqual(['a', '<ruby>x<rt>y</rt></ruby>', 'b']);
+	});
+});

--- a/src/lib/tokenize.test.ts
+++ b/src/lib/tokenize.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'bun:test';
+import { tokenizeSentence } from './tokenize';
+
+describe('tokenizeSentence', () => {
+	it('returns no tokens for an empty string', () => {
+		expect(tokenizeSentence('', 'en')).toEqual([]);
+	});
+
+	it('splits Latin text into words and whitespace segments', () => {
+		// Latin word segmentation is stable across ICU versions.
+		expect(tokenizeSentence('hello world', 'en')).toEqual(['hello', ' ', 'world']);
+	});
+
+	it('keeps punctuation as its own segment', () => {
+		expect(tokenizeSentence('the cat.', 'en')).toEqual(['the', ' ', 'cat', '.']);
+	});
+
+	it('treats "|" as an explicit boundary and drops it from the output', () => {
+		expect(tokenizeSentence('a|b', 'en')).toEqual(['a', 'b']);
+		expect(tokenizeSentence('a|b', 'en')).not.toContain('|');
+	});
+
+	it('forces a split at "|" even between otherwise-joined runs', () => {
+		// Without the pipe the segmenter would keep "onetwo" together.
+		expect(tokenizeSentence('one|two three', 'en')).toEqual(['one', 'two', ' ', 'three']);
+	});
+
+	it('keeps a ruby tag as a single indivisible token', () => {
+		const ruby = '<ruby>漢<rt>かん</rt></ruby>';
+		expect(tokenizeSentence(ruby, 'ja')).toEqual([ruby]);
+		expect(tokenizeSentence(`${ruby}字`, 'ja')[0]).toBe(ruby);
+	});
+
+	it('interleaves ruby tags with surrounding text without splitting them', () => {
+		const ruby = '<ruby>漢<rt>かん</rt></ruby>';
+		const tokens = tokenizeSentence(`foo ${ruby} bar`, 'en');
+		expect(tokens).toContain(ruby);
+		// The ruby tag survives intact — none of the other tokens is a fragment of it.
+		expect(tokens.filter((t) => t.includes('<ruby>'))).toEqual([ruby]);
+	});
+
+	it('reconstructs the original text (minus pipes) when tokens are rejoined', () => {
+		// Word boundaries for CJK depend on the ICU version, so assert the
+		// invariant that holds regardless: concatenation is lossless except for
+		// the explicit "|" boundary markers, which are consumed.
+		for (const [text, lang] of [
+			['hello world', 'en'],
+			['the cat.', 'en'],
+			['猫が魚を食べる', 'ja'],
+			['one|two three', 'en']
+		] as const) {
+			expect(tokenizeSentence(text, lang).join('')).toBe(text.replace(/\|/g, ''));
+		}
+	});
+
+	it('produces only non-empty tokens and never emits a bare "|"', () => {
+		const tokens = tokenizeSentence('猫が|魚を 食べる', 'ja');
+		expect(tokens.every((t) => t.length > 0)).toBe(true);
+		expect(tokens).not.toContain('|');
+	});
+
+	it('segments CJK text into multiple tokens', () => {
+		// Exact boundaries are ICU-dependent; just assert segmentation happened.
+		expect(tokenizeSentence('猫が魚を食べる', 'ja').length).toBeGreaterThan(1);
+	});
+});


### PR DESCRIPTION
## What

Adds unit tests for two core, pure, previously-untested helpers. No production code changes — tests only, so this is fully conflict-safe.

### `tokenize.ts` (`tokenizeSentence`)
- word / whitespace / punctuation segmentation for Latin (stable across ICU)
- `|` treated as an explicit boundary and dropped from output (incl. forcing a split between otherwise-joined runs)
- `<ruby>…</ruby>` tags kept as single indivisible tokens, even interleaved with surrounding text
- **lossless-reconstruction invariant**: `tokens.join('') === input.replace(/\|/g, '')` — holds regardless of ICU version
- CJK boundaries are ICU-version-dependent, so those cases assert *structure* (non-empty tokens, no bare `|`, >1 segment) rather than fixed splits

### `ruby.ts` (`parseRuby`, `rubyRule`)
- base/reading extraction from well-formed tags
- tolerance for a missing closing `</rt>`
- `{ rb: '⚠', rt: '⚠' }` sentinel for malformed / empty / empty-slot input
- `rubyRule` match + split-capture behaviour

## Why

Part of #50 (pure-helper test coverage). These two modules are the tokenization backbone and had zero tests. Adds a regression net before any future refactor of the segmentation path.

## Test plan

- [x] `bun test src/lib/` — 48 pass (was 29; +19 new)
- [x] `bun run check` — 0 errors
- [x] `bun run lint` — clean