### PR TITLE
test: cover remapSentenceConnections and addGlossAlignments (#50)

### DIFF
--- a/src/lib/gloss-align.test.ts
+++ b/src/lib/gloss-align.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'bun:test';
+import { addGlossAlignments } from './gloss-align';
+import { createSentence } from './types';
+
+// addGlossAlignments buckets tokens across sentences by their normalised gloss
+// key and wires them into equivalency groups: merging into an overlapping group,
+// else a label/surface-matching group, else a brand-new group (only when the
+// bucket spans >= 2 sentences). Groups are number[][][] (group -> sentence -> token ids).
+
+describe('addGlossAlignments', () => {
+	it('creates a new group for a gloss shared across two sentences', () => {
+		const en = createSentence('en', ['the', 'cat', 'eats'], ['the', 'cat', 'eat']);
+		const ja = createSentence('ja', ['猫', 'が', '食べる'], ['cat', 'TOP', 'eat']);
+		// "cat" -> group [s0 tok1, s1 tok0]; "eat" -> group [s0 tok2, s1 tok2].
+		// "the" and "TOP" appear in only one sentence, so they make no group.
+		expect(addGlossAlignments([en, ja], [], [0, 1])).toEqual([
+			[[1], [0]],
+			[[2], [2]]
+		]);
+	});
+
+	it('does not create a group for a gloss confined to a single sentence', () => {
+		expect(addGlossAlignments([createSentence('en', ['a'], ['x'])], [], [0])).toEqual([]);
+	});
+
+	it('buckets tokens by morphology-stripped gloss key (me.DAT == me.ACC == me)', () => {
+		const a = createSentence('en', ['me'], ['me.DAT']);
+		const b = createSentence('ja', ['私'], ['me.ACC']);
+		expect(addGlossAlignments([a, b], [], [0, 1])).toEqual([[[0], [0]]]);
+	});
+
+	it('matches by surface form when the gloss equals an existing token text', () => {
+		const en = createSentence('en', ['glass'], ['glass']);
+		const de = createSentence('de', ['Glas'], ['glass']);
+		expect(addGlossAlignments([en, de], [], [0, 1])).toEqual([[[0], [0]]]);
+	});
+
+	it('merges a new token into an existing group that already overlaps it', () => {
+		const en = createSentence('en', ['the', 'cat'], ['the', 'cat']);
+		const ja = createSentence('ja', ['猫'], ['cat']);
+		// Existing group already holds s0 tok1 ("cat"); the new s1 "cat" joins it.
+		expect(addGlossAlignments([en, ja], [[[1], []]], [1])).toEqual([[[1], [0]]]);
+	});
+
+	it('attaches a new gloss to a group whose glossless source token matches by surface', () => {
+		const src = createSentence('en', ['eat'], []); // no gloss, surface "eat"
+		const tgt = createSentence('ja', ['食べる'], ['eat']);
+		// Group holds the glossless source token; the new "eat" gloss is matched by surface.
+		expect(addGlossAlignments([src, tgt], [[[0], []]], [1])).toEqual([[[0], [0]]]);
+	});
+
+	it('preserves existing manual groups when no new sentence touches them', () => {
+		const a = createSentence('en', ['x'], []);
+		const b = createSentence('en', ['y'], []);
+		const manual = [[[0], [0]]];
+		expect(addGlossAlignments([a, b], manual, [])).toEqual(manual);
+	});
+
+	it('does not mutate the input equivalency array', () => {
+		const en = createSentence('en', ['cat'], ['cat']);
+		const ja = createSentence('ja', ['猫'], ['cat']);
+		const existing = [[[0], []]];
+		const snapshot = JSON.stringify(existing);
+		addGlossAlignments([en, ja], existing, [1]);
+		expect(JSON.stringify(existing)).toBe(snapshot);
+	});
+});

--- a/src/lib/sentence-edit.test.ts
+++ b/src/lib/sentence-edit.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'bun:test';
+import { remapSentenceConnections } from './sentence-edit';
+
+// remapSentenceConnections re-points the token indices of ONE sentence inside
+// the equivalency structure (number[][][]: group -> per-sentence -> token ids)
+// after that sentence is re-tokenised, using a character-level LCS diff between
+// the previous and next word arrays.
+
+describe('remapSentenceConnections', () => {
+	it('leaves connections unchanged when the tokenisation is identical', () => {
+		const eq = [
+			[[0], [0]],
+			[[1], [1]]
+		];
+		expect(remapSentenceConnections(eq, 0, ['a', 'b'], ['a', 'b'])).toEqual(eq);
+	});
+
+	it('maps a split token onto both of its resulting tokens', () => {
+		// "ab" (token 0) -> "a","b" (tokens 0 and 1)
+		expect(remapSentenceConnections([[[0], [0]]], 0, ['ab'], ['a', 'b'])).toEqual([[[0, 1], [0]]]);
+	});
+
+	it('maps two merged tokens onto the single resulting token', () => {
+		// "a","b" -> "ab": both old tokens now point at token 0
+		expect(
+			remapSentenceConnections(
+				[
+					[[0], []],
+					[[1], []]
+				],
+				0,
+				['a', 'b'],
+				['ab']
+			)
+		).toEqual([
+			[[0], []],
+			[[0], []]
+		]);
+	});
+
+	it('drops a connection to a token that was deleted', () => {
+		// "a","b","c" -> "a","c": the middle token (index 1) has no LCS image
+		expect(remapSentenceConnections([[[1], []]], 0, ['a', 'b', 'c'], ['a', 'c'])).toEqual([[[], []]]);
+	});
+
+	it('renumbers surviving tokens after a deletion', () => {
+		// token 0 ("a") stays 0; token 2 ("c") shifts to index 1
+		expect(
+			remapSentenceConnections(
+				[
+					[[0], []],
+					[[2], []]
+				],
+				0,
+				['a', 'b', 'c'],
+				['a', 'c']
+			)
+		).toEqual([
+			[[0], []],
+			[[1], []]
+		]);
+	});
+
+	it('only touches the edited sentence, leaving other sentences in the group intact', () => {
+		// Editing sentence 0; sentence 1's token list ([5]) is preserved verbatim.
+		expect(remapSentenceConnections([[[0], [5]]], 0, ['a'], ['a', 'b'])).toEqual([[[0], [5]]]);
+	});
+
+	it('de-duplicates when several old tokens collapse onto the same new token', () => {
+		// "a","b" both map into the merged "ab" within one entry -> single [0], not [0,0]
+		expect(remapSentenceConnections([[[0, 1], []]], 0, ['a', 'b'], ['ab'])).toEqual([[[0], []]]);
+	});
+});


### PR DESCRIPTION
## What

Unit tests for the two pure domain helpers that manipulate the equivalency structure (`number[][][]` — group → per-sentence → token ids). Tests only, no production changes — fully conflict-safe.

### `sentence-edit.ts` — `remapSentenceConnections`
Character-level LCS re-pointing of one sentence's token ids after it is re-tokenised:
- identity (no change)
- token **split** (`"ab"` → `"a","b"` maps onto both)
- token **merge** (`"a","b"` → `"ab"` collapses onto one)
- **deletion** drops the connection, and surviving tokens are **renumbered**
- only the **edited sentence** is touched; other sentences in the group are preserved verbatim
- **de-duplication** when multiple old tokens collapse onto the same new token

### `gloss-align.ts` — `addGlossAlignments`
Bucketing tokens by normalised gloss key and wiring them into groups:
- new group created only when a bucket spans **≥ 2 sentences**; single-sentence buckets skipped
- **morphology-key** bucketing (`me.DAT` == `me.ACC` == `me`)
- **surface-form** match (gloss equals an existing token's text)
- **overlap merge** into an existing group
- attaching to a group via a **glossless source** token's surface form
- **manual groups preserved** when untouched
- **input immutability** (the passed-in equivalency array is not mutated)

## Why

Part of #50 (pure-helper test coverage). These two encode the trickiest invariants in the app — connection survival across edits and auto-alignment of LLM translations — and had zero tests. Locks in current behaviour before any refactor.

## Test plan

- [x] `bun test src/lib/` — 44 pass (was 29; +15 new)
- [x] `bun run check` — 0 errors
- [x] `bun run lint` — clean